### PR TITLE
Update podunavailablebudget.md

### DIFF
--- a/docs/user-manuals/podunavailablebudget.md
+++ b/docs/user-manuals/podunavailablebudget.md
@@ -18,7 +18,7 @@ In voluntary disruption scenarios, PodUnavailableBudget can achieve the effect o
 A sample PodUnavailableBudget yaml looks like following:
 
 ```yaml
-apiVersion: apps.kruise.io/v1alpha1
+apiVersion: policy.kruise.io/v1alpha1
 kind: PodUnavailableBudget
 metadata:
   name: web-server-pub


### PR DESCRIPTION
Correcting sample PodUnavailableBudget yaml's 'apiVersion' title from wrong(app.kruise.io/v1alpha1) to right(policy.kruise.io/v1alpha1).
It will lead to creating PodUnavailableBudget failed if applying wrong 'apiVersion'(app.kruise.io/v1alpha1).
The error message is as follows：
```
cloneset.apps.kruise.io/web-server created
error: unable to recognize "pub-new.yaml": no matches for kind "PodUnavailableBudget" in version "app.kruise.io/v1alpha1"```