### PR TITLE
Update containerlaunchpriority.md

### DIFF
--- a/docs/user-manuals/containerlaunchpriority.md
+++ b/docs/user-manuals/containerlaunchpriority.md
@@ -20,6 +20,7 @@ It only requires you to add an annotation in Pod:
 ```yaml
 apiVersion: v1
 kind: Pod
+metadata:
   annotations:
     apps.kruise.io/container-launch-priority: Ordered
 spec:


### PR DESCRIPTION
kind: Pod
  annotations:
    apps.kruise.io/container-launch-priority: Ordered

is  error . lack  metadata