### PR TITLE
fix the spec.injectionStrategy.revisionName doc .

### DIFF
--- a/docs/user-manuals/sidecarset.md
+++ b/docs/user-manuals/sidecarset.md
@@ -236,7 +236,8 @@ spec:
   updateStrategy:
     partition: 90%
   injectionStrategy:
-    revisionName: <specific-controllerrevision-name>
+    revision:
+      revisionName: <specific-controllerrevision-name>
 ```
 
 #### select revision via custom version label
@@ -255,7 +256,8 @@ spec:
   updateStrategy:
     partition: 90%
   injectionStrategy:
-    customVersion: example/version-1
+    revision:
+      customVersion: example/version-1
 ```
 
 *Just choose one of the ways above.*

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/sidecarset.md
@@ -227,7 +227,8 @@ metadata:
 spec:
   ...
   injectionStrategy:
-    revisionName: <specific-controllerRevision-name>
+    revision:
+      revisionName: <specific-controllerRevision-name>
 ```
 
 #### 通过自定义版本标识指定注入的 Sidecar 版本
@@ -246,7 +247,8 @@ spec:
   updateStrategy:
     partition: 90%
   injectionStrategy:
-    customVersion: version-1
+    revision:
+      customVersion: version-1
 ```
 以上两种版本选择方式，任选其一即可。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/user-manuals/sidecarset.md
@@ -227,7 +227,8 @@ metadata:
 spec:
   ...
   injectionStrategy:
-    revisionName: <specific-controllerRevision-name>
+    revision: 
+      revisionName: <specific-controllerRevision-name>
 ```
 
 #### 通过自定义版本标识指定注入的 Sidecar 版本
@@ -246,7 +247,8 @@ spec:
   updateStrategy:
     partition: 90%
   injectionStrategy:
-    customVersion: version-1
+    revision:
+      customVersion: version-1
 ```
 以上两种版本选择方式，任选其一即可。
 

--- a/versioned_docs/version-v1.3/user-manuals/sidecarset.md
+++ b/versioned_docs/version-v1.3/user-manuals/sidecarset.md
@@ -236,7 +236,8 @@ spec:
   updateStrategy:
     partition: 90%
   injectionStrategy:
-    revisionName: <specific-controllerrevision-name>
+    revision:
+      revisionName: <specific-controllerrevision-name>
 ```
 
 #### select revision via custom version label
@@ -255,7 +256,8 @@ spec:
   updateStrategy:
     partition: 90%
   injectionStrategy:
-    customVersion: example/version-1
+    revision:
+      customVersion: example/version-1
 ```
 
 *Just choose one of the ways above.*


### PR DESCRIPTION
doc fix 
The spec.injectionStrategy.revisionName described in the official document and crd are inconsistent.
https://github.com/openkruise/kruise/issues/1123
