### PR TITLE
[Fix] ADD KRUISE_TERMINATE_SIDECAR ENV priority description

### DIFF
--- a/blog/2023-04-18-release-1.4.md
+++ b/blog/2023-04-18-release-1.4.md
@@ -69,6 +69,7 @@ Replace "example/quick-exit:v1.0.0" with the fast exit image that you have prepa
 - Containers with the environment variable KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT will be treated as sidecar containers, while other containers will be treated as main containers. The sidecar container will only be terminated after all main containers have completed:
   - Under the Never restart policy, once the main container exits, it will be considered "completed".
   - Under the OnFailure restart policy, the exit code of the main container must be 0 to be considered "completed".
+- In Pods on real nodes mode, `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` has a higher priority than `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE`
 
 ## Advanced Workload Improvement
 

--- a/docs/user-manuals/jobsidecarterminator.md
+++ b/docs/user-manuals/jobsidecarterminator.md
@@ -65,7 +65,8 @@ Replace `"example/quick-exit:v1.0.0"` with your prepared image.
 
 - The sidecars will be terminated when ALL main containers completed.
 
-- In `Never` restart policy settings, main container will be treated as `completed` once it exit.
+  - In `Never` restart policy settings, main container will be treated as `completed` once it exit.
 
-- In `OnFailure` restart policy settings, main container will be treated as `completed` once it exit and exit code must be `0`. 
+  - In `OnFailure` restart policy settings, main container will be treated as `completed` once it exit and exit code must be `0`. 
  
+- In Pods on real nodes mode, `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` has a higher priority than `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE`

--- a/i18n/zh/docusaurus-plugin-content-blog/2023-04-18-release-1.4.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2023-04-18-release-1.4.md
@@ -67,8 +67,9 @@ spec:
 - sidecar 容器必须能够响应 SIGTERM 信号，并且当收到此信号时，entrypoint 进程需要退出(即 sidecar 容器需要退出)，并且退出码应当为 0。
 - 该特性适用于任意 Job 类型 Workload 所管理的 Pod，只要他们的 RestartPolicy 为 Never/OnFailure 即可。
 - 具有环境变量 KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT 的容器将被视为 sidecar 容器，其他容器将被视为主容器，当所有主容器完成后，sidecar 容器才会被终止：
-- 在 Never 重启策略下，主容器一旦退出，将被视为"已完成"。
-- 在 OnFailure 重启策略下，主容器退出代码必须为0，才会被视为"已完成"。
+  - 在 Never 重启策略下，主容器一旦退出，将被视为"已完成"。
+  - 在 OnFailure 重启策略下，主容器退出代码必须为0，才会被视为"已完成"。
+- 且运行在普通节点方式下，`KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` 的优先级高于`KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE`
 
 ## 3. 增强版本的工作负载
 ### CloneSet 优化性能 ：新增 FeatureGate CloneSetEventHandlerOptimization

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/jobsidecarterminator.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/jobsidecarterminator.md
@@ -62,3 +62,5 @@ spec:
 - 具有环境变量 `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` 的容器将被视为 sidecar 容器，其他容器将被视为主容器，当**所有**主容器完成后，sidecar 容器才会被终止：
   - 在 `Never` 重启策略下，主容器一旦退出，将被视为"已完成"。
   - 在 `OnFailure` 重启策略下，主容器退出代码必须为`0`，才会被视为"已完成"。
+- 且运行在普通节点方式下，`KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` 的优先级高于`KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE`
+

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/user-manuals/jobsidecarterminator.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/user-manuals/jobsidecarterminator.md
@@ -62,3 +62,4 @@ spec:
 - 具有环境变量 `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` 的容器将被视为 sidecar 容器，其他容器将被视为主容器，当**所有**主容器完成后，sidecar 容器才会被终止：
   - 在 `Never` 重启策略下，主容器一旦退出，将被视为"已完成"。
   - 在 `OnFailure` 重启策略下，主容器退出代码必须为`0`，才会被视为"已完成"。
+- 且运行在普通节点方式下，`KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` 的优先级高于`KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE`

--- a/versioned_docs/version-v1.4/user-manuals/jobsidecarterminator.md
+++ b/versioned_docs/version-v1.4/user-manuals/jobsidecarterminator.md
@@ -65,7 +65,8 @@ Replace `"example/quick-exit:v1.0.0"` with your prepared image.
 
 - The sidecars will be terminated when ALL main containers completed.
 
-- In `Never` restart policy settings, main container will be treated as `completed` once it exit.
+  - In `Never` restart policy settings, main container will be treated as `completed` once it exit.
 
-- In `OnFailure` restart policy settings, main container will be treated as `completed` once it exit and exit code must be `0`. 
+  - In `OnFailure` restart policy settings, main container will be treated as `completed` once it exit and exit code must be `0`. 
  
+- In Pods on real nodes mode, `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` has a higher priority than `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE`


### PR DESCRIPTION
The document does not have any information about the priority of `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT` and `KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT_WITH_IMAGE` when two environment variables exist at the same time
 