### PR TITLE
add cri version notice in installation

### DIFF
--- a/.github/workflows/pre_dict.json
+++ b/.github/workflows/pre_dict.json
@@ -802,5 +802,9 @@
   "openapi",
   "patchesStrategicMerge",
   "tcpSocket",
-  "x-kubernetes-patch"
+  "x-kubernetes-patch",
+  "CronJob",
+  "GitOps\uff1f",
+  "Devops\uff1f",
+  "timeZone"
 ]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,8 @@ title: Installation
 
 - Since v1.6.0 (alpha/beta), OpenKruise requires **Kubernetes version >= 1.18**. However it's still possible to use OpenKruise with Kubernetes versions 1.16 and 1.17 as long as KruiseDaemon is not enabled(install/upgrade kruise charts with featureGates="KruiseDaemon=false")
 
+- Since v1.6.0 (alpha/beta), KruiseDaemon will **no longer support v1alpha2 CRI runtimes**. However, it is still possible to use OpenKruise on Kubernetes clusters with nodes that only support v1alpha2 CRI, as long as KruiseDaemon is not enabled (install/upgrade Kruise charts with featureGates="KruiseDaemon=false").
+
 ## Install with helm
 
 Kruise can be simply installed by helm v3.5+, which is a simple command-line tool and you can get it from [here](https://github.com/helm/helm/releases).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation.md
@@ -6,6 +6,8 @@ title: 安装
 
 - 从 v1.6.0 (alpha/beta) 开始，OpenKruise 要求在 **Kubernetes >= 1.18** 以上版本的集群中安装和使用。如果你关闭了 Kruise-Daemon 组件（featureGates="KruiseDaemon=false"），你依然可以在 K8S 1.16 和 1.17 的集群上安装和使用。
 
+- 从 v1.6.0 (alpha/beta) 开始，Kruise-Daemon 将**不再支持 v1alpha2 CRI 的运行时**。如果你关闭了 Kruise-Daemon 组件（featureGates="KruiseDaemon=false"），你依然可以在只支持 v1alpha2 CRI 的运行时节点所在集群上安装和使用 OpenKruise。
+
 ## 通过 helm 安装
 
 建议采用 helm v3.5+ 来安装 Kruise，helm 是一个简单的命令行工具可以从 [这里](https://github.com/helm/helm/releases) 获取。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/installation.md
@@ -6,6 +6,8 @@ title: 安装
 
 - 从 v1.6.0 (alpha/beta) 开始，OpenKruise 要求在 **Kubernetes >= 1.18** 以上版本的集群中安装和使用。如果你关闭了 Kruise-Daemon 组件（featureGates="KruiseDaemon=false"），你依然可以在 K8S 1.16 和 1.17 的集群上安装和使用。
 
+- 从 v1.6.0 (alpha/beta) 开始，Kruise-Daemon 将**不再支持 v1alpha2 CRI 的运行时**。如果你关闭了 Kruise-Daemon 组件（featureGates="KruiseDaemon=false"），你依然可以在只支持 v1alpha2 CRI 的运行时节点所在集群上安装和使用 OpenKruise。
+
 ## 通过 helm 安装
 
 建议采用 helm v3.5+ 来安装 Kruise，helm 是一个简单的命令行工具可以从 [这里](https://github.com/helm/helm/releases) 获取。

--- a/versioned_docs/version-v1.6/installation.md
+++ b/versioned_docs/version-v1.6/installation.md
@@ -6,6 +6,8 @@ title: Installation
 
 - Since v1.6.0 (alpha/beta), OpenKruise requires **Kubernetes version >= 1.18**. However it's still possible to use OpenKruise with Kubernetes versions 1.16 and 1.17 as long as KruiseDaemon is not enabled(install/upgrade kruise charts with featureGates="KruiseDaemon=false")
 
+- Since v1.6.0 (alpha/beta), KruiseDaemon will **no longer support v1alpha2 CRI runtimes**. However, it is still possible to use OpenKruise on Kubernetes clusters with nodes that only support v1alpha2 CRI, as long as KruiseDaemon is not enabled (install/upgrade Kruise charts with featureGates="KruiseDaemon=false").
+
 ## Install with helm
 
 Kruise can be simply installed by helm v3.5+, which is a simple command-line tool and you can get it from [here](https://github.com/helm/helm/releases).


### PR DESCRIPTION
add cri version notice in installation:


- Since v1.6.0 (alpha/beta), Kruise-Daemon will **no longer support v1alpha2 CRI runtimes**. However, it is still possible to use OpenKruise on Kubernetes clusters with nodes that only support v1alpha2 CRI, as long as KruiseDaemon is not enabled (install/upgrade Kruise charts with featureGates="KruiseDaemon=false").


中文

- 从 v1.6.0 (alpha/beta) 开始，Kruise-Daemon 将**不再支持 v1alpha2 CRI 的运行时**。如果你关闭了 Kruise-Daemon 组件（featureGates="KruiseDaemon=false"），你依然可以在只支持 v1alpha2 CRI 的运行时节点所在集群上安装和使用 OpenKruise。
