### PR TITLE
Add missing docs for kubectl-kruise rollout commands

### DIFF
--- a/docs/cli-tool/kubectl-plugin.md
+++ b/docs/cli-tool/kubectl-plugin.md
@@ -72,7 +72,6 @@ Manage rollout resources. This command provides deep inspection and control of t
 
 **Available Commands:**
 
-* **`describe`**: Provides a detailed, real-time view of the status of a Rollout object. This is invaluable for inspecting the progress of an update, debugging issues, and understanding the current state of your deployment.
 * **`approve`**: Manually promotes a Rollout to the next step. When a rollout is paused for manual verification, this command signals that the canary version has been validated and the full rollout can proceed.
 * **`undo`**: Rolls back a workload to its previous version. This is a critical command for quickly reverting a deployment if the new version is found to be unstable or buggy.
 * **`history`**: View the revision history of a workload.
@@ -84,9 +83,6 @@ Manage rollout resources. This command provides deep inspection and control of t
 **Usage Examples:**
 
 ```bash
-# Get a detailed description of the rollout 'my-rollout' in the 'production' namespace
-$ kubectl-kruise rollout describe rollout/my-rollout -n production
-
 $ kubectl kruise rollout undo cloneset/nginx
 
 # built-in statefulsets
@@ -97,6 +93,17 @@ $ kubectl kruise rollout status statefulsets.apps.kruise.io/sts2
 
 # approve a kruise rollout resource named "rollout-demo" in "ns-demo" namespace
 $ kubectl-kruise rollout approve rollout-demo -n ns-demo
+```
+### describe
+
+Perform a deep inspection of any Kruise object (including Rollouts).
+
+```bash
+# Inspect the “rollouts-demo” Rollout in namespace default:
+kubectl kruise describe rollout rollouts-demo -n default
+
+# You can also describe other kruise objects, for example:
+kubectl kruise describe cloneset my-cloneset -n default
 ```
 
 ### set

--- a/docs/cli-tool/kubectl-plugin.md
+++ b/docs/cli-tool/kubectl-plugin.md
@@ -68,9 +68,25 @@ It equals to `kubectl scale --replicas=3 cloneset nginx`.
 
 ### rollout
 
-Available commands: `history`, `pause`, `restart`, `resume`, `status`, `undo`, `approve`.
+Manage rollout resources. This command provides deep inspection and control of the Kruise Rollout objects.
+
+**Available Commands:**
+
+* **`describe`**: Provides a detailed, real-time view of the status of a Rollout object. This is invaluable for inspecting the progress of an update, debugging issues, and understanding the current state of your deployment.
+* **`approve`**: Manually promotes a Rollout to the next step. When a rollout is paused for manual verification, this command signals that the canary version has been validated and the full rollout can proceed.
+* **`undo`**: Rolls back a workload to its previous version. This is a critical command for quickly reverting a deployment if the new version is found to be unstable or buggy.
+* **`history`**: View the revision history of a workload.
+* **`pause`**: Pause a Rollout.
+* **`resume`**: Resume a paused Rollout.
+* **`restart`**: Restart a Rollout.
+* **`status`**: Display the status of a Rollout.
+
+**Usage Examples:**
 
 ```bash
+# Get a detailed description of the rollout 'my-rollout' in the 'production' namespace
+$ kubectl-kruise rollout describe rollout/my-rollout -n production
+
 $ kubectl kruise rollout undo cloneset/nginx
 
 # built-in statefulsets

--- a/docs/cli-tool/kubectl-plugin.md
+++ b/docs/cli-tool/kubectl-plugin.md
@@ -96,14 +96,11 @@ $ kubectl-kruise rollout approve rollout-demo -n ns-demo
 ```
 ### describe
 
-Perform a deep inspection of any Kruise object (including Rollouts).
+Perform a deep inspection of a Rollout resource, including its step status, history, conditions, and recent events.
 
 ```bash
 # Inspect the “rollouts-demo” Rollout in namespace default:
 kubectl kruise describe rollout rollouts-demo -n default
-
-# You can also describe other kruise objects, for example:
-kubectl kruise describe cloneset my-cloneset -n default
 ```
 
 ### set

--- a/rollouts/user-manuals/basic-usage.md
+++ b/rollouts/user-manuals/basic-usage.md
@@ -142,7 +142,7 @@ spec:
       - ... ...
 ```
 
-- **For method two**, you don't need to change anything before the next release. However, before confirming, you need to check the status of Rollout and use the update interface instead of the patch interface of Kubernetes client, or use our  [kubectl-kruise](https://github.com/openkruise/kruise-tools) tools.
+- **For method two**, you don't need to change anything before the next release. However, before confirming, you need to check the status of Rollout and use the update interface instead of the patch interface of Kubernetes client, or use our  [kubectl-kruise](https://github.com/openkruise/kruise-tools) tools. For a detailed guide on all rollout-related commands like `describe`, `approve`, and `undo`, please see the [Kubectl Plugin documentation](../cli-tool/kubectl-plugin.md#rollout).
 ```bash
 $ kubectl-kruise rollout approve rollout/<your-rollout-name> -n <your-rollout-namespace>
 ```

--- a/rollouts/user-manuals/basic-usage.md
+++ b/rollouts/user-manuals/basic-usage.md
@@ -107,7 +107,26 @@ $ kubectl patch deployment workload-demo -p \
 Wait a while, we will see the Deployment status show **Only 1 Pod** is upgraded.
 ![](../../static/img/rollouts/basic-1st-batch.jpg)
 
-### Step 3: Continue to release the 2-nd batch
+### Step 3: Inspect or continue your rollout
+**Inspect** the rollout’s detailed status, steps, and recent events:
+```bash
+$ kubectl-kruise describe rollout rollouts-demo -n default
+```
+**Example output:**
+```
+Name:         rollouts-demo
+Namespace:    default
+Status:       Healthy
+Strategy:     Canary
+Step:         1/4
+Steps:
+  - Replicas: 1   State: StepUpgrade
+  - Replicas: 2
+  - Replicas: 3
+  - Replicas: 4
+```
+
+**Approve** the next batch if everything looks good:
 ```bash
 $ kubectl-kruise rollout approve rollout/rollouts-demo -n default
 ```


### PR DESCRIPTION
This PR resolves the issue of missing documentation for the `kubectl-kruise` rollout commands.

It enhances the documentation by:
1.  Expanding the `rollout` section in `docs/cli-tool/kubectl-plugin.md` to serve as a detailed reference for the `describe`, `approve`, and `undo` sub-commands.
2.  Adding a link from the `rollouts/user-manuals/basic-usage.md` guide to this new reference, providing better context for users.

This approach creates a single source of truth for the CLI commands, improving clarity and long-term maintainability.