### PR TITLE
Add missing docs for rollout.Spec.Disabled and rollout.Spec.strategy.paused

### DIFF
--- a/rollouts/user-manuals/api-specifications.md
+++ b/rollouts/user-manuals/api-specifications.md
@@ -104,6 +104,26 @@ There are 3 major parts of api specifications you should pay attention to:
 - Config your deployment strategy before releasing: Tell Rollout how to roll your workload and traffic.
 
 ## API Details
+
+### Rollout Spec Fields
+| Field               | Type    | Default | Description   
+|
+|---------------------|---------|---------|-----------------------------------------------------------------------------|
+| `disabled`          | boolean | false   | When true, completely disables Rollout reconciliation 
+| `strategy.paused`   | boolean | false   | When true, pauses rollout progression until manually resumed               |
+| `workloadRef`       | Object  |         | Reference to the workload being managed                                    |
+| `strategy`          | Object  |         | Rollout strategy configuration (canary or blue-green)                      |
+
+**Note: Difference between Disabled and Paused**
+- **Disabled**: Stops all Rollout reconciliation. The controller ignores this Rollout until re-enabled.
+- **Paused**: Keeps the Rollout active but halts progression between steps. Useful for inspections or troubleshooting.
+
+**Version Compatibility**
+- `blueGreen` strategy requires Kruise Rollout v0.5.0+
+- `spec.strategy.paused` is available in both v1alpha1 and v1beta1 APIs
+- `spec.disabled` is available in both v1alpha1 and v1beta1 APIs
+- The `blueGreen` strategy is only supported in v1beta1 API
+
 ### Workload Binding API (Mandatory)
 Tell Kruise Rollout which workload should be bounded:
 
@@ -312,6 +332,12 @@ spec:
 </Tabs>
 
 ### Strategy API (Mandatory)
+
+| Field        | Type    | Default | Description                                                               |
+|--------------|---------|---------|---------------------------------------------------------------------------|
+| `paused`     | boolean | false   | When true, pauses rollout progression until manually resumed             |
+| `canary`     | Object  | nil     | Canary strategy configuration                                            |
+| `blueGreen`  | Object  | nil     | Blue-green strategy configuration (requires v0.5.0+)                     |
 
 `canary`  is used for canary strategy and multi-batch strategy, while `blueGreen` is used for blue-green strategy. These two are mutually exclusive; they cannot both be empty or both be non-empty. The `blueGreen` strategy was introduced in Kruise-Rollout versions higher than v0.5.0 and is not supported in the v1alpha1 API.
 

--- a/rollouts/user-manuals/api-specifications.md
+++ b/rollouts/user-manuals/api-specifications.md
@@ -106,13 +106,13 @@ There are 3 major parts of api specifications you should pay attention to:
 ## API Details
 
 ### Rollout Spec Fields
-| Field               | Type    | Default | Description   
-|
-|---------------------|---------|---------|-----------------------------------------------------------------------------|
-| `disabled`          | boolean | false   | When true, completely disables Rollout reconciliation 
-| `strategy.paused`   | boolean | false   | When true, pauses rollout progression until manually resumed               |
-| `workloadRef`       | Object  |         | Reference to the workload being managed                                    |
-| `strategy`          | Object  |         | Rollout strategy configuration (canary or blue-green)                      |
+
+| Field             | Type    | Default | Description                                                              |
+|-------------------|---------|---------|--------------------------------------------------------------------------|
+| `disabled`        | boolean | false   | When true, completely disables Rollout reconciliation                    |
+| `strategy.paused` | boolean | false   | When true, pauses rollout progression until manually resumed             |
+| `workloadRef`     | Object  |         | Reference to the workload being managed                                  |
+| `strategy`        | Object  |         | Rollout strategy configuration (canary or blue‑green)                     |
 
 **Note: Difference between Disabled and Paused**
 - **Disabled**: Stops all Rollout reconciliation. The controller ignores this Rollout until re-enabled.

--- a/rollouts/user-manuals/basic-usage.md
+++ b/rollouts/user-manuals/basic-usage.md
@@ -39,6 +39,48 @@ spec:
 ```
 
 ### Step 1: Prepare and apply Rollout configuration
+
+### Disabling a Rollout
+Completely stop Rollout reconciliation (controller will ignore this resource):
+```bash
+kubectl apply -f - <<EOF
+apiVersion: rollouts.kruise.io/v1beta1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+  namespace: default
+spec:
+  disabled: true  # Disables Rollout reconciliation
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: workload-demo
+  strategy:
+    canary:
+      steps: [...] 
+EOF
+```
+### Pausing a Rollout
+Halt progression while keeping Rollout active (resume later by setting to `false`):
+```bash
+kubectl apply -f - <<EOF
+apiVersion: rollouts.kruise.io/v1beta1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+  namespace: default
+spec:
+  strategy:
+    paused: true   # Pauses rollout progression
+    canary:
+      steps: [...] 
+  workloadRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: workload-demo
+EOF
+```
+
 Assume that you want to use multi-batch update strategy to upgrade your Deployment from "version-1" to "version-2":
 - In the 1-st batch: **Only 1** Pod should be upgraded;
 - In the 2-nd batch: **50%** Pods should be upgraded, i.e., **5 updated Pods**;


### PR DESCRIPTION
This PR adds missing documentation for two new Rollout API fields:

Fixes #248 

1. **`spec.disabled`**

   * Declared under **Rollout Spec Fields**
   * Type: `boolean` (default: `false`)
   * When `true`, completely disables controller reconciliation for this Rollout resource.

2. **`spec.strategy.paused`**

   * Declared under **Rollout Spec Fields** and **Strategy API (Mandatory)**
   * Type: `boolean` (default: `false`)
   * When `true`, pauses rollout progression between steps without disabling the Rollout.

Additional changes:

* **Usage examples** in `basic-usage.md` under **Step 1** illustrate how to disable or pause a Rollout via `kubectl apply`.
* A **“Disabled vs Paused”** note clarifies their different behaviors.
* A **version-compatibility** note outlines which API versions support these fields and the blue‑green strategy.
