### PR TITLE
Add Adopters and Supporters sections to openkruise website

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,6 +157,7 @@ function getNextVersionName() {
             activeBasePath: 'kruisegame',
           },
           {to: '/blog', label: 'Blog', position: 'left'},
+          {to: '/adopters', label: 'Adopters', position: 'left'},
           {
             type: 'localeDropdown',
             position: 'right',

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -268,5 +268,41 @@
     "theme.SearchBar.label": {
       "message": "Search",
       "description": "The ARIA label and placeholder for search button"
+    },
+    "Adopters": {
+      "message": "采用者",
+      "description": "Adopters section title"
+    },
+    "Companies and organizations using OpenKruise in production": {
+      "message": "在生产环境中使用OpenKruise的公司和组织",
+      "description": "Adopters section subtitle"
+    },
+    "Supporters": {
+      "message": "支持者",
+      "description": "Supporters section title"
+    },
+    "Recognition": {
+      "message": "认可",
+      "description": "Recognition section title"
+    },
+    "Use Case": {
+      "message": "使用场景",
+      "description": "Use case label in adopter cards"
+    },
+    "Companies that have contributed to OpenKruise with meaningful contributions": {
+      "message": "为OpenKruise做出有意义贡献的公司",
+      "description": "Supporters section subtitle on homepage"
+    },
+    "Become a Supporter": {
+      "message": "成为支持者",
+      "description": "Button text to become a supporter"
+    },
+    "Already using Kruise? Fill the details in the below link": {
+      "message": "已经在使用Kruise？请在下面的链接中填写详细信息",
+      "description": "Text for become adopter section"
+    },
+    "Open": {
+    "message": "打开",
+    "description": "Button text to open"
     }
   }

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -10,5 +10,9 @@
     "item.label.Blog": {
       "message": "博客",
       "description": "Navbar item with label Blog"
+    },
+    "item.label.Adopters": {
+      "message": "采用者",
+      "description": "Navbar item with label Adopters"
     }
   }

--- a/src/components/SupportersSection.js
+++ b/src/components/SupportersSection.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import { supporters } from '../data/adopters';
+import styles from './SupportersSection.module.css';
+
+function SupporterLogo({ supporter }) {
+  return (
+    <div className={clsx('col col--3', styles.supporterItem)}>
+      <div className={styles.logoContainer}>
+        {supporter.logo ? (
+          <img 
+            src={supporter.logo} 
+            alt={supporter.name}
+            className={styles.logo}
+          />
+        ) : (
+          <div className={styles.placeholderLogo}>
+            {supporter.name}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+
+
+export default function SupportersSection() {
+  return (
+    <>
+      {supporters && supporters.length > 0 && (
+        <section className={styles.supportersSection}>
+          <div className="container">
+            <div className="text--center margin-bottom--lg">
+              <h2 className={styles.sectionTitle}>
+                <Translate>Recognition</Translate>
+              </h2>
+              <p className={styles.sectionSubtitle}>
+                <Translate>
+                  Companies that have contributed to OpenKruise with meaningful contributions
+                </Translate>
+              </p>
+            </div>
+
+            <div className="row">
+              {supporters.map((supporter, idx) => (
+                <SupporterLogo key={idx} supporter={supporter} />
+              ))}
+            </div>
+
+            <div className="text--center margin-top--lg">
+              <Link
+                className={styles.becomeSupporter}
+                href="https://kubernetes.slack.com/channels/openkruise">
+                <Translate>Become a Supporter</Translate>
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/src/components/SupportersSection.module.css
+++ b/src/components/SupportersSection.module.css
@@ -1,0 +1,127 @@
+.supportersSection {
+  padding: 4rem 0;
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.recognitionSection {
+  padding: 4rem 0;
+  background-color: var(--ifm-background-color);
+}
+
+.sectionTitle {
+  margin-bottom: 1rem;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  font-family: var(--ifm-font-family-base);
+}
+
+.sectionSubtitle {
+  margin-bottom: 0;
+  font-size: 1.125rem;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  font-family: var(--ifm-font-family-base);
+}
+
+.supporterItem {
+  margin-bottom: 2rem;
+  padding: 0 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.logoContainer {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-card-border-radius);
+  padding: 1rem;
+  height: 100px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  box-shadow: var(--ifm-global-shadow-lw);
+}
+
+.logoContainer:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.logo {
+  max-height: 60px;
+  max-width: 100%;
+  object-fit: contain;
+  filter: grayscale(100%);
+  transition: filter 0.2s ease-in-out;
+}
+
+.logoContainer:hover .logo {
+  filter: grayscale(0%);
+}
+
+.placeholderLogo {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600);
+  text-align: center;
+  padding: 0.5rem;
+  line-height: 1.2;
+}
+
+.becomeSupporter {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--ifm-color-primary);
+  color: white !important;
+  text-decoration: none;
+  border-radius: var(--ifm-button-border-radius);
+  font-weight: var(--ifm-font-weight-normal);
+  font-size: var(--ifm-font-size-base);
+  font-family: var(--ifm-font-family-base);
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.becomeSupporter:hover {
+  background-color: var(--ifm-color-primary-dark);
+  color: white !important;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+@media screen and (max-width: 996px) {
+  .supporterItem {
+    --ifm-col-width: calc(50% - var(--ifm-spacing-horizontal));
+  }
+  
+  .sectionTitle {
+    font-size: 2rem;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .supporterItem {
+    --ifm-col-width: calc(50% - var(--ifm-spacing-horizontal));
+  }
+  
+  .supportersSection {
+    padding: 2rem 0;
+  }
+  
+  .sectionTitle {
+    font-size: 1.75rem;
+  }
+  
+  .logoContainer {
+    height: 80px;
+  }
+  
+  .logo {
+    max-height: 50px;
+  }
+}

--- a/src/data/adopters.js
+++ b/src/data/adopters.js
@@ -1,0 +1,357 @@
+// Adopters data extracted from GitHub issue #289
+export const adopters = [
+  {
+    name: "DouyuTV",
+    location: "Wuhan, China",
+    contact: "yanwei@douyu.tv",
+    purpose: "Using Kruise for managing statefulset applications. We need parallel updates"
+  },
+  {
+    name: "Sto",
+    location: "Shanghai, China",
+    contact: "yaofang@sto.cn",
+    purpose: "Using Kruise for managing statefulset applications, we need local upgrade"
+  },
+  {
+    name: "Boss直聘",
+    location: "Beijing, China",
+    contact: "sunfuze@kanzhun.com",
+    purpose: "sidecar,cloneset,statefulset for Corporate Paas"
+  },
+  {
+    name: "hangyinxiaofei",
+    location: "HangZhou, China",
+    contact: "506636022@qq.com",
+    purpose: "sidecar,cloneset,statefulset for Corporate Paas",
+  },
+  {
+    name: "vanyitech",
+    location: "ShenZhen, China",
+    contact: "564470785@qq.com",
+    purpose: "Using Kruise for managing clonese tapplications, we need local upgrade。Using BroadcastJob to clean images",
+  },
+  {
+    name: "Lyft",
+    location: "San Francisco, CA, USA",
+    contact: "reverson@lyft.com",
+    purpose: "Using Kruise CloneSets and bin packing for selective downscaling of stateful nodes.",
+  },
+  {
+    name: "Ctrip",
+    location: "ShangHai, China",
+    contact: "shi_yan@trip.com",
+    purpose: "Using CloneSet and AdvanceStatefulSet for manage stateless and stateful apps. We need in place and partial update.",
+  },
+  {
+    name: "Dmall",
+    location: "Beijing/ChengDu, China",
+    contact: "yongzhi.yang@dmall.com",
+    purpose: "Advance HPA, In-Place Update, Sidecar management, etc.",
+  },
+  {
+    name: "佐疆科技",
+    location: "上海, 中国",
+    contact: "liudehan_xin@163.com",
+    purpose: "使用克隆集和预陈述集管理无状态和有状态的应用程序。我们需要就地和部分更新。",
+  },
+  {
+    name: "Bringg",
+    location: "Tel-Aviv, Israel",
+    contact: "roman@bringg.com",
+    purpose: "Advanced DaemonSet, to solve load balancer connection to api gateway running with deamonset",
+  },
+  {
+    name: "xiaohongshu",
+    location: "ShangHai, China",
+    contact: "wenyi@xiaohongshu.com",
+    purpose: "Using CloneSet and BroadcastJob for manage stateless apps and async job.",
+  },
+  {
+    name: "享住智慧",
+    location: "成都, 中国",
+    contact: "1135656335@qq.com",
+    purpose: "使用克隆集和预陈述集管理有状态的应用程序。",
+  },
+  {
+    name: "bixin",
+    location: "ShangHai, China",
+    contact: "zhangjunjie@bixin.cn",
+    purpose: "Using CloneSet and BroadcastJob for manage stateless apps and async job.",
+  },
+  {
+    name: "VIPKID",
+    location: "Beijing, China",
+    contact: "caodi@vipkid.com.cn",
+    purpose: "Using BroadcastJob for managing clusters",
+  },
+  {
+    name: "zhangmen",
+    location: "ShangHai, China",
+    contact: "shanjie.han@zhangmen.com",
+    purpose: "Using CloneSet and AdvanceStatefulSet to deploy app on production env. We need in place and partial update.",
+  },
+  {
+    name: "ihomefnt",
+    location: "NanJing, China",
+    contact: "693404752@qq.com",
+    purpose: "Using sidecarset to inject container .",
+  },
+  {
+    name: "Arkane Systems",
+    location: "Wichita, KS",
+    contact: "avatar@arkane-systems.net",
+    purpose: "Using BroadcastJob/AdvancedCronTab for periodic per-node tasks and cleanup; using SidecarSet to inject local maintenance containers.",
+  },
+  {
+    name: "永辉科技中心",
+    location: "ShangHai, China",
+    contact: "mosesyou1994@gmail.com",
+    purpose: "Using CloneSet and SidecarSet to in-place upgrade and manage sidecar pod.",
+  },
+  {
+    name: "跟谁学",
+    location: "北京, 中国",
+    contact: "1711358893@qq.com",
+    purpose: "使用UnitedDeployment做单元化部署",
+  },
+  {
+    name: "OPPO",
+    location: "Shenzhen, China",
+    contact: "xuxinkun@gmail.com",
+    purpose: "Using Kruise for managing large-scale statefulsets to in-place update.",
+  },
+  {
+    name: "火花思维",
+    location: "北京, 中国",
+    contact: "quxiaotong@huohua.cn",
+    purpose: "使用cloneset管理应用更新",
+  },
+  {
+    name: "Spectro Cloud",
+    location: "Santa Clara, US",
+    contact: "rishi@spectrocloud.com",
+    purpose: "Using Kruise for managing periodic node actions.",
+  },
+  {
+    name: "Suning.cn",
+    location: "Nanjing, China",
+    contact: "18044103@suning.com",
+    purpose: "Using CloneSet and SidecarSet to manage stateless apps and sidecar.",
+  },
+  {
+    name: "Deepexi",
+    location: "Shenzhen, China",
+    contact: "huxuze@deepexi.com",
+    purpose: "Using Kruise for managing large-scale applications and sidecars.",
+  },
+  {
+    name: "哈啰出行",
+    location: "ShangHai/HangZhou, China",
+    contact: "jiyufeng048@hellobike.com",
+    purpose: "In-Place Update, Sidecar management, etc.",
+  },
+  {
+    name: "joyy",
+    location: "GuangZhou, China",
+    contact: "yuheshuang@joyy.sg",
+    purpose: "Using CloneSet and AdvanceStatefulSet for manage stateless and stateful apps. We need in place and partial update.",
+  },
+  {
+    name: "Mobvista",
+    location: "Guangzhou, China",
+    contact: "junwei.liang@mintegral.com",
+    purpose: "Using Kruise for log collect sidecarsets and manage stateless cloneset apps.",
+  },
+  {
+    name: "深圳凤凰木网络有限公司",
+    location: "ShenZhen, China",
+    contact: "zhangbch@txxy.com",
+    purpose: "Using CloneSet for manage stateless apps.",
+  },
+  {
+    name: "xiaomi",
+    location: "BeiJing, China",
+    contact: "xudongyang@xiaomi.com",
+    purpose: "Using CloneSet for stateless apps.",
+  },
+  {
+    name: "Netease",
+    location: "BeiJing, China",
+    contact: "wangmaocheng@corp.netease.com",
+    purpose: "Using SidecarSet to in-place upgrade and manage sidecar pod.",
+  },
+  {
+    name: "MeiTuan Finance",
+    location: "ShangHai, China",
+    contact: "hantmac@outlook.com",
+    purpose: "Using CloneSet and AdvanceStatefulSet for manage stateless and stateful apps. We need in place and partial update.",
+  },
+  {
+    name: "Shopee",
+    location: "Shenzhen, China",
+    contact: "chaowang.chen@shopee.com",
+    purpose: "Using CloneSet for stateless apps.",
+  },
+  {
+    name: "Esign",
+    location: "Hangzhou, China",
+    contact: "dijiu@tsign.cn",
+    purpose: "Using sidecarSet for sidecar container.",
+  },
+  {
+    name: "Wholee",
+    location: "HangZhou, China",
+    contact: "lijiangzhou@wholeeprime.com",
+    purpose: "Using CloneSet for manage stateless apps.",
+  },
+  {
+    name: "LinkedIn",
+    location: "Sunnyvale, U.S.",
+    contact: "shuliang@linkedin.com",
+    purpose: "Using CloneSet for managing large-scale workloads (in-place updates, enhanced PVC support)",
+  },
+  {
+    name: "雪球",
+    location: "Beijing, China",
+    contact: "hekuangsheng@xueqiu.com",
+    purpose: "sidecar,cloneset,statefulset for Corporate Paas",
+  },
+  {
+    name: "f6car",
+    location: "Nanjing, China",
+    contact: "qixiaobo@f6car.cn",
+    purpose: "Using Kruise for ResourceDistribution",
+  },
+  {
+    name: "安心云人事",
+    location: "Shanghai, China",
+    contact: "mengxiaodong@julanling.com",
+    purpose: "Using Kruise and Rollouts for our business",
+  },
+  {
+    name: "广州雷猴软件-噢啦研发部",
+    location: "中国广州",
+    contact: "zhengliang_w@oola.cn",
+    purpose: "使用CloneSet提高CICD效率、管理业务应用workloads（如原地升级）；使用SidecarSet管理sidecar容器。",
+  },
+  {
+    name: "youzan",
+    location: "Hangzhou, China",
+    contact: "cheng.zhang@youzan.com",
+    purpose: "Using SidecarSet to manage sidecar include inject and inplace update.",
+  },
+  {
+    name: "LilithGames",
+    location: "Shanghai, China",
+    contact: "opensource@lilith.com",
+    purpose: "Using statefulset and cloneset to inplace update.",
+  },
+  {
+    name: "Ferguson",
+    location: "Virginia, USA",
+    contact: "martin.francis@ferguson.com",
+    purpose: "For adaptive scheduling of PODs using WorkloadSpread",
+  },
+  {
+    name: "Baidu",
+    location: "Beijing, China",
+    contact: "ruisen_liu@163.com",
+    purpose: "Using CloneSet to in-place upgrade. Use SidecarSet to inject sidecar and canary update.",
+  },
+  {
+    name: "Ximalaya",
+    location: "Shanghai, China",
+    contact: "jason.cai@ximalaya.com",
+    purpose: "Using SidecarSet to maintain lifecycle of sidecar containers.",
+  },
+  {
+    name: "Tongcheng",
+    location: "Suzhou,Beijing China",
+    contact: "peng.xin@ly.com",
+    purpose: "PersistentPodState custom workload support/Using PersistentPodState for calico fixed IP",
+  },
+  {
+    name: "MeiTuan",
+    location: "Beijing, China",
+    contact: "sunshuai09@meituan.com",
+    purpose: "CloneSet with PVC for data persistence.",
+  },
+  {
+    name: "DiPeak",
+    location: "Beijing, China",
+    contact: "wangxiaokai@dipeak.com",
+    purpose: "Using CloneSet to in-place upgrade, and so on.",
+  },
+  {
+    name: "冠赢互娱",
+    location: "HangZhou.China",
+    contact: "grand_sheng@163.com",
+    purpose: "Use CloneSet to manage stateless services, realize game server creation and state management through kruise and kruisegame.",
+  },
+  {
+    name: "bilibili",
+    location: "Shanghai, China",
+    contact: "lichengbing@bilibili.com",
+    purpose: "Complete complex customization of game publishing scenarios using GameServerSet and SidecarSet.",
+  },
+  {
+    name: "Hangzhou Youxing Technology Co., Ltd",
+    location: "hangzhou, China",
+    contact: "hua.zhu5@geely.com",
+    purpose: "Using rollout to restart app in steps",
+  },
+  {
+    name: "Uber",
+    location: "Sunnyvale, US",
+    contact: "suhao@uber.com",
+    purpose: "Use CloneSets for in-place update",
+  },
+  {
+    name: "FUTU",
+    location: "Shenzhen, China",
+    contact: "chrisdeng@futunn.com.com",
+    purpose: "Using Kruise for managing large-scale applications and sidecars.",
+  },
+  {
+    name: "竞技世界",
+    location: "Beijing.China",
+    contact: "dejinx@qq.com",
+    purpose: "Use CloneSet to manage stateless services, realize game server creation and state management through kruise and kruisegame.",
+  },
+  {
+    name: "HUYA",
+    location: "GuangZhou, China",
+    contact: "tianshuai1@huya.com",
+    purpose: "Using Kruise for managing large-scale workloads（in-place update support）.",
+  },
+  {
+    name: "FVT",
+    location: "Netherlands",
+    contact: "v.vanwieringen@flikweertvision.nl",
+    purpose: "Using ImagepullJobs to ensure seamless upgrades of containers for a large number of edge devices",
+  },
+  {
+    name: "Keep",
+    location: "Beijing.China",
+    contact: "i@sre.wiki",
+    purpose: "1. 使用 workloadspreading 能力控制 hpa 时多个池子的副本数 2. 使用 asts 管理一些服务",
+  },
+  {
+    name: "Dewu",
+    location: "Shanghai, China",
+    contact: "fengyinqiao888@gmail.com",
+    purpose: "Build federated middleware-operator using kruise's advanced-sts with karmada.",
+  },
+  {
+    name: "Bytedance",
+    location: "Hangzhou, China",
+    contact: "yankewen.1@bytedance.com",
+    purpose: "Using Kruise for managing stateful applications for DataBase. Many advanced workloads and features are used such as PUB、ASTS、ADS、CS ... . We enhanced the capabilities of kruise-daemon as a component similar to kubelet on lower versions of Kubernetes, such as in-place pod updates and resource statistics.",
+  }
+];
+
+// Supporters data
+export const supporters = [
+
+];
+

--- a/src/pages/adopters.js
+++ b/src/pages/adopters.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import clsx from 'clsx';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import Translate, { translate } from '@docusaurus/Translate';
+import { adopters } from '../data/adopters';
+import styles from './adopters.module.css';
+
+function AdopterCard({ adopter }) {
+  return (
+    <div className={clsx('col col--3', styles.adopterCard)}>
+      <div className={styles.card}>
+        <div className={styles.cardHeader}>
+          <h3 className={styles.companyName}>{adopter.name}</h3>
+          <p className={styles.location}>{adopter.location}</p>
+        </div>
+        <div className={styles.cardBody}>
+          <div className={styles.useCase}>
+            <h4><Translate>Use Case</Translate></h4>
+            <p>{adopter.purpose}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+
+function AdoptersSection() {
+  return (
+    <section className={styles.adoptersSection}>
+      <div className="container">
+        <div className="row">
+          {adopters.map((adopter, idx) => (
+            <AdopterCard key={idx} adopter={adopter} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+
+
+function BecomeAdopterSection() {
+  return (
+    <section className={styles.becomeAdopterSection}>
+      <div className="container">
+        <div className="text--center">
+          <h2 className={styles.becomeAdopterTitle}>
+            <Translate>Already using Kruise? Fill the details in the below link</Translate>
+          </h2>
+          <Link
+            className={styles.becomeAdopterButton}
+            href="https://github.com/openkruise/kruise/issues/289">
+            <Translate>Open</Translate>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function Adopters() {
+  return (
+    <Layout
+      title={translate({
+        message: 'Adopters & Supporters',
+        description: 'The title of the adopters page',
+      })}
+      description={translate({
+        message: 'Companies and organizations using OpenKruise and supporting its development',
+        description: 'The description of the adopters page',
+      })}
+    >
+      <header className={clsx('hero hero--primary', styles.heroBanner)}>
+        <div className="container">
+          <h1 className="hero__title">
+            <Translate>Adopters</Translate>
+          </h1>
+          <p className="hero__subtitle">
+            <Translate>
+              Companies and organizations using OpenKruise in production
+            </Translate>
+          </p>
+        </div>
+      </header>
+
+      <main>
+        <AdoptersSection />
+        <BecomeAdopterSection />
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/adopters.module.css
+++ b/src/pages/adopters.module.css
@@ -1,0 +1,123 @@
+.heroBanner {
+  padding: 4rem 0;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.adoptersSection {
+  padding: 4rem 0;
+  background-color: var(--ifm-background-color);
+}
+
+.becomeAdopterSection {
+  padding: 4rem 0;
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.adopterCard {
+  margin-bottom: 2rem;
+  padding: 0 1rem;
+}
+
+.card {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-card-border-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
+  height: 100%;
+  padding: 1.5rem;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.cardHeader {
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  padding-bottom: 1rem;
+}
+
+.companyName {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+}
+
+.location {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ifm-color-emphasis-700);
+  font-style: italic;
+}
+
+.cardBody {
+  flex: 1;
+}
+
+.useCase h4 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.useCase p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.becomeAdopterTitle {
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+  font-family: var(--ifm-font-family-base);
+}
+
+.becomeAdopterButton {
+  display: inline-block;
+  padding: 0.5rem 1.5rem;
+  background-color: var(--ifm-color-primary);
+  color: white !important;
+  text-decoration: none;
+  border-radius: var(--ifm-button-border-radius);
+  font-weight: var(--ifm-font-weight-normal);
+  font-size: var(--ifm-font-size-base);
+  font-family: var(--ifm-font-family-base);
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.becomeAdopterButton:hover {
+  background-color: var(--ifm-color-primary-dark);
+  color: white !important;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+@media screen and (max-width: 996px) {
+  .adopterCard {
+    --ifm-col-width: calc(50% - var(--ifm-spacing-horizontal));
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .adopterCard {
+    --ifm-col-width: calc(100% - var(--ifm-spacing-horizontal));
+  }
+  
+  .heroBanner {
+    padding: 2rem 0;
+  }
+  
+  .adoptersSection,
+  .becomeAdopterSection {
+    padding: 2rem 0;
+  }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,6 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import GitHubButton from 'react-github-btn';
 import styles from './index.module.css';
 import HomepageFeatures from '../components/HomepageFeatures';
+import SupportersSection from '../components/SupportersSection';
 
 function Feature({ imgUrl, title, description, reverse }) {
   return (
@@ -80,6 +81,9 @@ export default function Home() {
           </section>
         </div>
       </main>
+
+      <SupportersSection />
+
       <div className={clsx('hero', styles.hero)}>
       
         <div className="container text--center">


### PR DESCRIPTION
### Description
- This PR implements the adopters and supporters sections, showcasing companies using openKruise and those contributing to its development.

### Changes made:
- Homepage
  - Added supporters section displaying company logos (4 per row)
  - Added "Become a Supporter" button linked to official Slack channel
  
- New Adopters Page
  - Displayed companies with their location and use cases
  - added "already using Kruise?" section with GitHub issue link
 
- Datas
  - created `src/data/adopters.js` with company data
  - Adopters: company name, location, contact, and use case
  - Supporters: company name, logo, contributor count, and description
 
- UI/UX Improvements
  - Consistent typography using existing font system
  - Professional card-based design with hover effects
  - Responsive layout for all screen sizes

- Internationalization
  - Added Chinese translations for all new content
  - both english and chinese versions

### Does this pull request fix one issue?
- Yes - Fixes #243 

### Special notes for reviews:
  - Adopters show company info only (no logos), supporters show logos only
  - all new components use existing `var(--ifm-font-family-base)` system
  - cards adapt from 4 to 2 to 1 per row on smaller screens
  
  
### Supporters section is ready, but we have to add data. At first it will not be there. In images it is shown by creating a dummy data
### Supporters section is in homepage and for Adopters i created a new page

![Screenshot 2025-07-09 222455](https://github.com/user-attachments/assets/434fc0a4-5b2a-4be6-959b-8f8756371dea)
![Screenshot 2025-07-09 222522](https://github.com/user-attachments/assets/b5e99824-de78-42d2-90a9-61da278072bd)
![Screenshot 2025-07-09 222603](https://github.com/user-attachments/assets/ff77fce7-f7f2-4f6b-a7e0-3c73e91141d1)
![Screenshot 2025-07-09 230628](https://github.com/user-attachments/assets/9c7bcdbd-3543-4da0-bea4-526576e82f5d)