### PR TITLE
Enable native dependency caching in workflows

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -82,7 +82,6 @@ jobs:
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
-          cache: 'pip'
       - name: TypoCheck
         run: |
           pip3 install bs4 markdown html2markdown language_tool_python
@@ -98,7 +97,6 @@ jobs:
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
-          cache: 'pip'
       - name: StructCheck
         run: |
           cd .github/workflows && python3 version_struct_check.py

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '18'
+          cache: 'npm'
       - name: Test Build
         run: |
           if [ -e package-lock.json ]; then
@@ -39,6 +40,7 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '18'
+          cache: 'npm'
       - uses: webfactory/ssh-agent@v0.5.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
@@ -80,6 +82,7 @@ jobs:
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
+          cache: 'pip'
       - name: TypoCheck
         run: |
           pip3 install bs4 markdown html2markdown language_tool_python
@@ -90,9 +93,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          cache: true
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
+          cache: 'pip'
       - name: StructCheck
         run: |
           cd .github/workflows && python3 version_struct_check.py


### PR DESCRIPTION
This PR adds dependency caching for npm, pip, and Go modules using the modern, built-in features of the setup-* actions.

This change significantly speeds up CI build times, reduces network usage, and makes the workflow more efficient for all contributors.