### PR TITLE
fix: typos in docs

### DIFF
--- a/docs/user-manuals/advancedstatefulset.md
+++ b/docs/user-manuals/advancedstatefulset.md
@@ -228,7 +228,7 @@ Advanced StatefulSet adds a `podUpdatePolicy` field in `spec.updateStrategy.roll
 which controls recreate or in-place update for Pods.
 
 - `ReCreate` controller will delete old Pods and create new ones. This is the same behavior as default StatefulSet.
-- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please ready the concept doc below.
+- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please read the concept doc below.
 - `InPlaceOnly` controller will in-place update Pod instead of recreating them. With `InPlaceOnly` policy, user cannot modify any fields other than the fields that supported to in-place update.
 
 **You may need to read the [concept doc](../core-concepts/inplace-update) for more details of in-place update.**

--- a/i18n/zh/docusaurus-plugin-content-docs-rollouts/current/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-rollouts/current/introduction.md
@@ -41,7 +41,7 @@ Kruise Rollouts 与 [Argo Rollout](https://argoproj.github.io/rollouts/) 和 [Fl
 | 架构      | Bypass                                                                  | 新的工作负载类型                                 | Bypass                                   |
 | 插拔和热切换  | 是                                                                       | 否                                        | 否                                        |
 | 发布类型    | 多批次、金丝雀、A/B测试、全链路灰度、蓝绿                                                      | 多批次、金丝雀、蓝绿、A/B测试                         | 金丝雀、蓝绿、A/B测试                             |
-| 工作负载类型  | Deployment、StatefulSet、CloneSet、Advanced StatefulSet、Advanced DaemonSet | Agro-Rollout                             | Deployment、DaemonSet                     | 
+| 工作负载类型  | Deployment、StatefulSet、CloneSet、Advanced StatefulSet、Advanced DaemonSet | Argo-Rollout                             | Deployment、DaemonSet                     | 
 | 流量类型    | Ingress、GatewayAPI、CRD（需要 Lua 脚本）                                       | Ingress、GatewayAPI、APISIX、Traefik、SMI 等等 | Ingress、GatewayAPI、APISIX、Traefik、SMI 等等 |
 | 迁移成本    | 无需迁移工作负载和Pods                                                           | 必须迁移工作负载和Pods                            | 必须迁移Pods                                 | 
 | HPA 兼容性 | 是                                                                       | 是                                        | 否                                        |

--- a/rollouts/introduction.md
+++ b/rollouts/introduction.md
@@ -37,7 +37,7 @@ Kruise Rollouts vs. [Argo Rollout](https://argoproj.github.io/rollouts/) and [Fl
 | Architecture                | Bypass                                                       | A new workload type                                | Bypass                                             |
 | Plug and Play, Hot-Swapping | Yes                                                          | No                                                 | No                                                 |
 | Release Type                | Multi-Batch, Canary, A/B Testing, End-to-End Canary, Blue-Green | Multi-Batch, Canary, Blue-Green, A/B Testing       | Canary, Blue-Green, A/B Testing                    |
-| Workload Type               | Deployment,StatefulSet,CloneSet,Advanced StatefulSet,Advanced DaemonSet | Agro-Rollout                                       | Deployment. DaemonSet                              |
+| Workload Type               | Deployment,StatefulSet,CloneSet,Advanced StatefulSet,Advanced DaemonSet | Argo-Rollout                                       | Deployment. DaemonSet                              |
 | Traffic Type                | Ingress, GatewayAPI, CRD (Need Lua Script)                   | Ingress, GatewayAPI, APISIX, Traefik, SMI and more | Ingress, GatewayAPI, APISIX, Traefik, SMI and more |
 | Migration Costs             | No need migrate your workloads and pods                      | Must migrate your workloads and pods               | Must migrate your pods                             |
 | HPA compatible              | Yes                                                          | Yes                                                | No                                                 |

--- a/versioned_docs/version-v1.5/user-manuals/advancedstatefulset.md
+++ b/versioned_docs/version-v1.5/user-manuals/advancedstatefulset.md
@@ -68,7 +68,7 @@ Advanced StatefulSet adds a `podUpdatePolicy` field in `spec.updateStrategy.roll
 which controls recreate or in-place update for Pods.
 
 - `ReCreate` controller will delete old Pods and create new ones. This is the same behavior as default StatefulSet.
-- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please ready the concept doc below.
+- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please read the concept doc below.
 - `InPlaceOnly` controller will in-place update Pod instead of recreating them. With `InPlaceOnly` policy, user cannot modify any fields other than the fields that supported to in-place update.
 
 **You may need to read the [concept doc](../core-concepts/inplace-update) for more details of in-place update.**

--- a/versioned_docs/version-v1.6/user-manuals/advancedstatefulset.md
+++ b/versioned_docs/version-v1.6/user-manuals/advancedstatefulset.md
@@ -68,7 +68,7 @@ Advanced StatefulSet adds a `podUpdatePolicy` field in `spec.updateStrategy.roll
 which controls recreate or in-place update for Pods.
 
 - `ReCreate` controller will delete old Pods and create new ones. This is the same behavior as default StatefulSet.
-- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please ready the concept doc below.
+- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please read the concept doc below.
 - `InPlaceOnly` controller will in-place update Pod instead of recreating them. With `InPlaceOnly` policy, user cannot modify any fields other than the fields that supported to in-place update.
 
 **You may need to read the [concept doc](../core-concepts/inplace-update) for more details of in-place update.**

--- a/versioned_docs/version-v1.7/user-manuals/advancedstatefulset.md
+++ b/versioned_docs/version-v1.7/user-manuals/advancedstatefulset.md
@@ -205,7 +205,7 @@ Advanced StatefulSet adds a `podUpdatePolicy` field in `spec.updateStrategy.roll
 which controls recreate or in-place update for Pods.
 
 - `ReCreate` controller will delete old Pods and create new ones. This is the same behavior as default StatefulSet.
-- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please ready the concept doc below.
+- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please read the concept doc below.
 - `InPlaceOnly` controller will in-place update Pod instead of recreating them. With `InPlaceOnly` policy, user cannot modify any fields other than the fields that supported to in-place update.
 
 **You may need to read the [concept doc](../core-concepts/inplace-update) for more details of in-place update.**

--- a/versioned_docs/version-v1.8/user-manuals/advancedstatefulset.md
+++ b/versioned_docs/version-v1.8/user-manuals/advancedstatefulset.md
@@ -228,7 +228,7 @@ Advanced StatefulSet adds a `podUpdatePolicy` field in `spec.updateStrategy.roll
 which controls recreate or in-place update for Pods.
 
 - `ReCreate` controller will delete old Pods and create new ones. This is the same behavior as default StatefulSet.
-- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please ready the concept doc below.
+- `InPlaceIfPossible` controller will try to in-place update Pod instead of recreating them if possible. Please read the concept doc below.
 - `InPlaceOnly` controller will in-place update Pod instead of recreating them. With `InPlaceOnly` policy, user cannot modify any fields other than the fields that supported to in-place update.
 
 **You may need to read the [concept doc](../core-concepts/inplace-update) for more details of in-place update.**


### PR DESCRIPTION
## Description and Changes Introduced

Fix typos `Agro` -> `Argo`

Fix typos `Ready` -> `Read`


## Related MRs:
- Superseeds: https://github.com/openkruise/openkruise.io/pull/55

## Testing Instructions
- Deploy or run docs locally
- notice the fixed spelling