### PR TITLE
Fix GitHub Star button aria-label in homepage (correct OpenKruise repo)

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,7 +56,7 @@ export default function Home() {
             data-icon="octicon-star"
             data-size="large"
             data-show-count="true"
-            aria-label="Star facebook/metro on GitHub">
+            aria-label="Star openkruise/kruise on GitHub">
             Star
           </GitHubButton>
           <p className="hero__subtitle">{siteConfig.tagline}</p>


### PR DESCRIPTION
###  Accessibility Improvements
- **Updated `aria-label`**: Changed label to `aria-label="Star openkruise/kruise on GitHub"` to ensure contextually accurate metadata.
- **Screen Reader Optimization**: Screen readers now correctly announce: *"Star openkruise/kruise on GitHub"*.
- **Code Cleanup**: Removed an outdated and misleading reference to `facebook/metro` to prevent developer confusion.