### PR TITLE
Fix missing SHA pin for webfactory/ssh-agent in documentation workflow for security consistency

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - uses: webfactory/ssh-agent@v0.5.0
+      - uses: webfactory/ssh-agent@6b2f2c5354ff41f1edbbf7a17ea9b6178c89be9f # v0.5.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
       - name: Release to GitHub Pages


### PR DESCRIPTION

The `webfactory/ssh-agent` action in `.github/workflows/documentation.yaml` was using a version tag (`v0.5.0`) instead of a commit SHA pin. This inconsistency exposed the workflow to potential **supply chain attacks**, as version tags can be moved or overwritten by maintainers.

Replaced `webfactory/ssh-agent@v0.5.0` with its immutable commit SHA to match the security standards of the rest of the workflow:

* **Commit SHA**: `6b2f2c5354ff41f1edbbf7a17ea9b6178c89be9f`
- **Improves supply chain security**: Ensures the action is locked to a specific, audited state.
- **Consistent security practices**: Aligns all GitHub Actions in the file under the same SHA pinning standard.
- **No functional changes**: The workflow uses the same action version, just through a more secure reference.