### PR TITLE
docs: fix broken relative links in introduction What's Next section

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/introduction.md
@@ -65,5 +65,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture).


### PR DESCRIPTION
  ## What this PR does / why we need it

  The "What's Next" section at the bottom of `docs/introduction.md` had two broken links:

  - Start to install OpenKruise (./docs/installation).
  - Learn OpenKruise's Architecture (./docs/core-concepts/architecture).

  Because this file lives at `/docs/introduction`, the `./docs/` prefix resolves to `/docs/docs/installation` — a path that doesn't exist. Fixed both links by removing the redundant `./docs/` prefix. Applied the same fix to the Chinese translation.

  ## Which issue(s) this PR fixes

 Fixes #328

  ## Special notes for your reviewer

  Two files changed, same two-line fix in each:
  - `docs/introduction.md` lines 59–60
  - `i18n/zh/docusaurus-plugin-content-docs/current/introduction.md` lines 68–69