### PR TITLE
docs: fix broken navigation links and some old blog typos

### DIFF
--- a/blog/2021-12-13-release-1.0.md
+++ b/blog/2021-12-13-release-1.0.md
@@ -5,7 +5,7 @@ authors: [FillZpp]
 tags: [release]
 ---
 
-We’re pleased to announce the release of Kubernetes 1.0, which is a CNCF Sandbox level project.
+We’re pleased to announce the release of OpenKruise 1.0, which is a CNCF Sandbox level project.
 
 [OpenKruise](https://openkruise.io) is an extended component suite for Kubernetes, which mainly focuses on application automations, such as deployment, upgrade, ops and availability protection. Mostly features provided by OpenKruise are built primarily based on CRD extensions. They can work in pure Kubernetes clusters without any other dependences.
 

--- a/blog/2022-03-29-release-1.1.md
+++ b/blog/2022-03-29-release-1.1.md
@@ -5,7 +5,7 @@ authors: [FillZpp]
 tags: [release]
 ---
 
-We’re pleased to announce the release of Kubernetes 1.1, which is a CNCF Sandbox level project.
+We’re pleased to announce the release of OpenKruise 1.1, which is a CNCF Sandbox level project.
 
 [OpenKruise](https://openkruise.io) is an extended component suite for Kubernetes, which mainly focuses on application automations, such as deployment, upgrade, ops and availability protection. Mostly features provided by OpenKruise are built primarily based on CRD extensions. They can work in pure Kubernetes clusters without any other dependences.
 

--- a/docs/core-concepts/inplace-update.md
+++ b/docs/core-concepts/inplace-update.md
@@ -171,7 +171,7 @@ Note that if you have some nodes of virtual-kubelet type, kruise-daemon may not 
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Kruise Advanced Workloads support modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/docs/user-manuals/advanceddaemonset.md
+++ b/docs/user-manuals/advanceddaemonset.md
@@ -302,7 +302,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Advanced DaemonSet supports modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/docs/user-manuals/advancedstatefulset.md
+++ b/docs/user-manuals/advancedstatefulset.md
@@ -294,7 +294,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Advanced StatefulSet supports modifying container resources (CPU/Memory) during in-place updates. 
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/docs/user-manuals/cloneset.md
+++ b/docs/user-manuals/cloneset.md
@@ -1046,7 +1046,7 @@ All operations applicable to a Complete CloneSet can also be applied to a Failed
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 CloneSet supports modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/ci-pipeline-image-predownload.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/ci-pipeline-image-predownload.md
@@ -114,7 +114,7 @@ spec:
 #### Kruise CloneSet & Advanced StatefulSet原地升级内置镜像预热能力
 **Note：此种场景不再需要下发ImagePullJob CRD资源**
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet & Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 ```
 # Firstly add openkruise charts repository if you haven't do this.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/inplace-update.md
@@ -169,7 +169,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Kruise Advanced Workloads 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/advanceddaemonset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/advanceddaemonset.md
@@ -294,7 +294,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Advanced DaemonSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 <Tabs>
@@ -360,7 +360,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.3.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
 DaemonSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 DaemonSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/advancedstatefulset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/advancedstatefulset.md
@@ -120,7 +120,7 @@ ordinals.start: 0				    ordinals.start: 3
 
 **FEATURE STATE:** Kruise v1.1.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
 你可以使用 `.spec.persistentVolumeClaimRetentionPolicy` 字段来控制在StatefulSet生命周期中是否以及何时删除它所创建的PVC。
 
 这个功能与上游 StatefulSet (K8s >= 1.23 [alpha]) 提供的相同，可以参考[上游文档](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。
@@ -285,7 +285,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Advanced StatefulSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml
@@ -325,7 +325,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.10.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate`
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate`
 feature-gate，
 Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/cloneset.md
@@ -1029,7 +1029,7 @@ reason: ProgressDeadlineExceeded
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 CloneSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 <Tabs>
@@ -1097,7 +1097,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.9.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 CloneSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。如果需要调整并发度或控制预热时机，不同版本的配置方式有所差异：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/deletionprotection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/deletionprotection.md
@@ -8,7 +8,7 @@ title: Deletion Protection
 
 ## 使用方式
 
-首先，需要在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
+首先，需要在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
 
 然后，用户可以给一些特定资源对象加上 `policy.kruise.io/delete-protection` 标签，值可以是：
 - `Always`: 这个对象禁止被删除，除非上述 label 被去掉

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/best-practices/ci-pipeline-image-predownload.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/best-practices/ci-pipeline-image-predownload.md
@@ -114,7 +114,7 @@ spec:
 #### Kruise CloneSet & Advanced StatefulSet原地升级内置镜像预热能力
 **Note：此种场景不再需要下发ImagePullJob CRD资源**
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet & Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 ```
 # Firstly add openkruise charts repository if you haven't do this.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/advanceddaemonset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/advanceddaemonset.md
@@ -164,7 +164,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.3.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
 DaemonSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 DaemonSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/advancedstatefulset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/advancedstatefulset.md
@@ -182,7 +182,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.10.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 Advanced StatefulSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。
@@ -270,7 +270,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
 你可以使用 `.spec.persistentVolumeClaimRetentionPolicy` 字段来控制在StatefulSet生命周期中是否以及何时删除它所创建的PVC。
 
 这个功能与上游 StatefulSet (K8s >= 1.23 [alpha]) 提供的相同，可以参考[上游文档](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/cloneset.md
@@ -476,7 +476,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.9.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 CloneSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/deletionprotection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/deletionprotection.md
@@ -8,7 +8,7 @@ title: Deletion Protection
 
 ## 使用方式
 
-首先，需要在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
+首先，需要在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
 
 然后，用户可以给一些特定资源对象加上 `policy.kruise.io/delete-protection` 标签，值可以是：
 - `Always`: 这个对象禁止被删除，除非上述 label 被去掉

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/best-practices/ci-pipeline-image-predownload.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/best-practices/ci-pipeline-image-predownload.md
@@ -114,7 +114,7 @@ spec:
 #### Kruise CloneSet & Advanced StatefulSet原地升级内置镜像预热能力
 **Note：此种场景不再需要下发ImagePullJob CRD资源**
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet & Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 ```
 # Firstly add openkruise charts repository if you haven't do this.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/advanceddaemonset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/advanceddaemonset.md
@@ -164,7 +164,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.3.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
 DaemonSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 DaemonSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/advancedstatefulset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/advancedstatefulset.md
@@ -182,7 +182,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.10.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 Advanced StatefulSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。
@@ -270,7 +270,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
 你可以使用 `.spec.persistentVolumeClaimRetentionPolicy` 字段来控制在StatefulSet生命周期中是否以及合适删除它所创建的PVC。
 
 这个功能与上游 StatefulSet (K8s >= 1.23 [alpha]) 提供的相同，可以参考[上游文档](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/cloneset.md
@@ -476,7 +476,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.9.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 CloneSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/deletionprotection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/deletionprotection.md
@@ -8,7 +8,7 @@ title: Deletion Protection
 
 ## 使用方式
 
-首先，需要在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
+首先，需要在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
 
 然后，用户可以给一些特定资源对象加上 `policy.kruise.io/delete-protection` 标签，值可以是：
 - `Always`: 这个对象禁止被删除，除非上述 label 被去掉

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/best-practices/ci-pipeline-image-predownload.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/best-practices/ci-pipeline-image-predownload.md
@@ -114,7 +114,7 @@ spec:
 #### Kruise CloneSet & Advanced StatefulSet原地升级内置镜像预热能力
 **Note：此种场景不再需要下发ImagePullJob CRD资源**
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet & Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 ```
 # Firstly add openkruise charts repository if you haven't do this.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/advanceddaemonset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/advanceddaemonset.md
@@ -164,7 +164,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.3.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
 DaemonSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 DaemonSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/advancedstatefulset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/advancedstatefulset.md
@@ -116,7 +116,7 @@ ordinals.start: 0				    ordinals.start: 3
 
 **FEATURE STATE:** Kruise v1.1.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
 你可以使用 `.spec.persistentVolumeClaimRetentionPolicy` 字段来控制在StatefulSet生命周期中是否以及何时删除它所创建的PVC。
 
 这个功能与上游 StatefulSet (K8s >= 1.23 [alpha]) 提供的相同，可以参考[上游文档](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。
@@ -255,7 +255,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.10.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 Advanced StatefulSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/cloneset.md
@@ -510,7 +510,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.9.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 CloneSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/deletionprotection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/deletionprotection.md
@@ -8,7 +8,7 @@ title: Deletion Protection
 
 ## 使用方式
 
-首先，需要在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
+首先，需要在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
 
 然后，用户可以给一些特定资源对象加上 `policy.kruise.io/delete-protection` 标签，值可以是：
 - `Always`: 这个对象禁止被删除，除非上述 label 被去掉

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/best-practices/ci-pipeline-image-predownload.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/best-practices/ci-pipeline-image-predownload.md
@@ -114,7 +114,7 @@ spec:
 #### Kruise CloneSet & Advanced StatefulSet原地升级内置镜像预热能力
 **Note：此种场景不再需要下发ImagePullJob CRD资源**
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet & Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 ```
 # Firstly add openkruise charts repository if you haven't do this.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/core-concepts/inplace-update.md
@@ -169,7 +169,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Kruise Advanced Workloads 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/advanceddaemonset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/advanceddaemonset.md
@@ -164,7 +164,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Advanced DaemonSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml
@@ -205,7 +205,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.3.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
 DaemonSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 DaemonSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/advancedstatefulset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/advancedstatefulset.md
@@ -120,7 +120,7 @@ ordinals.start: 0				    ordinals.start: 3
 
 **FEATURE STATE:** Kruise v1.1.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
 你可以使用 `.spec.persistentVolumeClaimRetentionPolicy` 字段来控制在StatefulSet生命周期中是否以及何时删除它所创建的PVC。
 
 这个功能与上游 StatefulSet (K8s >= 1.23 [alpha]) 提供的相同，可以参考[上游文档](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。
@@ -285,7 +285,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Advanced StatefulSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml
@@ -325,7 +325,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.10.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate`
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate`
 feature-gate，
 Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/cloneset.md
@@ -510,7 +510,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 CloneSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml
@@ -551,7 +551,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.9.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 CloneSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/deletionprotection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/deletionprotection.md
@@ -8,7 +8,7 @@ title: Deletion Protection
 
 ## 使用方式
 
-首先，需要在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
+首先，需要在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
 
 然后，用户可以给一些特定资源对象加上 `policy.kruise.io/delete-protection` 标签，值可以是：
 - `Always`: 这个对象禁止被删除，除非上述 label 被去掉

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/best-practices/ci-pipeline-image-predownload.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/best-practices/ci-pipeline-image-predownload.md
@@ -114,7 +114,7 @@ spec:
 #### Kruise CloneSet & Advanced StatefulSet原地升级内置镜像预热能力
 **Note：此种场景不再需要下发ImagePullJob CRD资源**
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet & Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 ```
 # Firstly add openkruise charts repository if you haven't do this.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/core-concepts/inplace-update.md
@@ -169,7 +169,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Kruise Advanced Workloads 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/advanceddaemonset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/advanceddaemonset.md
@@ -294,7 +294,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Advanced DaemonSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 <Tabs>
@@ -360,7 +360,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.3.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForDaemonSetUpdate` feature-gate，
 DaemonSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 DaemonSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/advancedstatefulset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/advancedstatefulset.md
@@ -120,7 +120,7 @@ ordinals.start: 0				    ordinals.start: 3
 
 **FEATURE STATE:** Kruise v1.1.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `StatefulSetAutoDeletePVC` feature-gate，
 你可以使用 `.spec.persistentVolumeClaimRetentionPolicy` 字段来控制在StatefulSet生命周期中是否以及何时删除它所创建的PVC。
 
 这个功能与上游 StatefulSet (K8s >= 1.23 [alpha]) 提供的相同，可以参考[上游文档](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)。
@@ -285,7 +285,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 Advanced StatefulSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml
@@ -325,7 +325,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.10.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate`
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate`
 feature-gate，
 Advanced StatefulSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/cloneset.md
@@ -623,7 +623,7 @@ reason: ProgressDeadlineExceeded
 
 **FEATURE STATE:** Kruise v1.8.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `InPlaceWorkloadVerticalScaling`，
 CloneSet 支持在原地升级过程中修改容器资源（CPU/Memory）。该功能允许用户直接更新以下字段而不触发 Pod 重建：
 
 ```yaml
@@ -664,7 +664,7 @@ spec:
 
 **FEATURE STATE:** Kruise v0.9.0
 
-如果你在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
+如果你在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用了 `PreDownloadImageForInPlaceUpdate` feature-gate，
 CloneSet 控制器会自动在所有旧版本 pod 所在 node 节点上预热你正在灰度发布的新版本镜像。 这对于应用发布加速很有帮助。
 
 默认情况下 CloneSet 每个新镜像预热时的并发度都是 `1`，也就是一个个节点拉镜像。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/deletionprotection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/deletionprotection.md
@@ -8,7 +8,7 @@ title: Deletion Protection
 
 ## 使用方式
 
-首先，需要在[安装或升级 Kruise](../installation##optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
+首先，需要在[安装或升级 Kruise](../installation#optional-feature-gate) 的时候启用 `ResourcesDeletionProtection` feature-gate。
 
 然后，用户可以给一些特定资源对象加上 `policy.kruise.io/delete-protection` 标签，值可以是：
 - `Always`: 这个对象禁止被删除，除非上述 label 被去掉

--- a/versioned_docs/version-v1.8/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.8/core-concepts/inplace-update.md
@@ -171,7 +171,7 @@ Note that if you have some nodes of virtual-kubelet type, kruise-daemon may not 
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Kruise Advanced Workloads support modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.8/user-manuals/advanceddaemonset.md
+++ b/versioned_docs/version-v1.8/user-manuals/advanceddaemonset.md
@@ -170,7 +170,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Advanced DaemonSet supports modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.8/user-manuals/advancedstatefulset.md
+++ b/versioned_docs/version-v1.8/user-manuals/advancedstatefulset.md
@@ -294,7 +294,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Advanced StatefulSet supports modifying container resources (CPU/Memory) during in-place updates. 
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.8/user-manuals/cloneset.md
+++ b/versioned_docs/version-v1.8/user-manuals/cloneset.md
@@ -533,7 +533,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 CloneSet supports modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.9/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.9/core-concepts/inplace-update.md
@@ -171,7 +171,7 @@ Note that if you have some nodes of virtual-kubelet type, kruise-daemon may not 
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Kruise Advanced Workloads support modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.9/user-manuals/advanceddaemonset.md
+++ b/versioned_docs/version-v1.9/user-manuals/advanceddaemonset.md
@@ -302,7 +302,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Advanced DaemonSet supports modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.9/user-manuals/advancedstatefulset.md
+++ b/versioned_docs/version-v1.9/user-manuals/advancedstatefulset.md
@@ -294,7 +294,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 Advanced StatefulSet supports modifying container resources (CPU/Memory) during in-place updates. 
 This feature allows users to directly update the following fields without triggering Pod recreation:
 

--- a/versioned_docs/version-v1.9/user-manuals/cloneset.md
+++ b/versioned_docs/version-v1.9/user-manuals/cloneset.md
@@ -639,7 +639,7 @@ All operations applicable to a Complete CloneSet can also be applied to a Failed
 
 **FEATURE STATE:** Kruise v1.8.0
 
-If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation##optional-feature-gate),
+If you have enabled `InPlaceWorkloadVerticalScaling` during [Kruise installation or upgrade](../installation#optional-feature-gate),
 CloneSet supports modifying container resources (CPU/Memory) during in-place updates.
 This feature allows users to directly update the following fields without triggering Pod recreation:
 


### PR DESCRIPTION
### Summary

Hi! I was going through the documentation and noticed a few small bugs that I've fixed in this PR:

### Changes made

**1. Fixed broken internal links**

- I found around 60 places where the “Kruise installation or upgrade” link was not scrolling to the correct section (Optional: feature-gate) on the target page.
- The issue was caused by a small typo in the anchor links — they were using ##optional-feature-gate instead of #optional-feature-gate.
-  I fixed these links across:
         - current documentation,
         - versioned documentation,
         - and Chinese translation files.

**2. Corrected release blog typos**

- The release posts for v1.0 and v1.1 accidentally mentioned “Kubernetes 1.0” instead of “OpenKruise 1.0”.
- I updated the wording to keep the project history accurate and consistent.

### Verification

- Tested locally using the development server
- Verified that all updated links now navigate correctly
- No functional or content changes apart from the fixes mentioned above