### PR TITLE
fix(config): correct Algolia env var names so workflow secrets are actually read

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -133,9 +133,9 @@ function getNextVersionName() {
           '⭐️ If you like OpenKruise, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/openkruise/kruise">GitHub</a>! ⭐️',
       },
       algolia: {
-        apiKey: process.env.Algolia_API_KEY || '72ec0a3c892141cf32490c676bb66628',
+        apiKey: process.env.ALGOLIA_API_KEY || '72ec0a3c892141cf32490c676bb66628',
         indexName: 'openkruise',
-        appId: process.env.Algolia_APP_ID || 'FKASWWQYOP',
+        appId: process.env.ALGOLIA_APP_ID || 'FKASWWQYOP',
         contextualSearch: true,
         searchParameters: {},
       },


### PR DESCRIPTION
## Problem

The deploy workflow exports `ALGOLIA_API_KEY` and `ALGOLIA_APP_ID` from GitHub Secrets:

```yaml id="ys9rdj"
ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
```

and writes them into `.env` using uppercase variable names.

However, `docusaurus.config.js` was reading them as:

```js id="9rydfm"
process.env.Algolia_API_KEY
process.env.Algolia_APP_ID
```

Since environment variables are case-sensitive, the secret values were never actually being used. The build always fell back to the hardcoded Algolia credentials already present in the config.

I verified this through local reproduction and git history. The mismatch appears to have been introduced in the GitHub Actions security update and remained unnoticed afterward.

## Fix

Updated `docusaurus.config.js` to correctly read:

```js id="swiy0x"
process.env.ALGOLIA_API_KEY
process.env.ALGOLIA_APP_ID
```

## Why this matters

With this fix:

* Algolia key rotation through GitHub Secrets now works correctly during deployment.
* The deployment workflow finally uses the intended secret values.
* Local development behavior remains unchanged because the existing fallback values are still preserved.