### PR TITLE
docs: migrate HPA examples to autoscaling/v2

### DIFF
--- a/.github/workflows/pre_dict.json
+++ b/.github/workflows/pre_dict.json
@@ -64,6 +64,7 @@
     "Autoscaler",
     "availableReplicas",
     "available；",
+    "averageUtilization",
     "awk",
     "aws",
     "awsCredentialsDir",

--- a/blog/2025-02-19-elastic-components.md
+++ b/blog/2025-02-19-elastic-components.md
@@ -418,7 +418,7 @@ spec:
                     value: SERVERLESS
 ---
 # Combine with HPA for automatic scaling
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: elastic-app-hpa
@@ -426,10 +426,12 @@ spec:
   minReplicas: 1
   maxReplicas: 100
   metrics:
-    - resource:
+    - type: Resource
+      resource:
         name: cpu
-        targetAverageUtilization: 2
-      type: Resource
+        target:
+          type: Utilization
+          averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/docs/best-practices/hpa-configuration.md
+++ b/docs/best-practices/hpa-configuration.md
@@ -5,12 +5,14 @@ title: HPA configuration
 Kruise workloads, such as CloneSet, Advanced StatefulSet, UnitedDeployment, are all implemented scale subresource,
 which means they allow systems like HorizontalPodAutoscaler and PodDisruptionBudget interact with these resources.
 
+Examples use `apiVersion: autoscaling/v2` (stable since Kubernetes 1.23). The older `autoscaling/v2beta1` and `autoscaling/v2beta2` APIs were removed in Kubernetes 1.25 and 1.26, respectively. For resource metrics, use `resource.target.type: Utilization` and `averageUtilization` instead of the deprecated `targetAverageUtilization` field.
+
 ### Example
 
 Just set the CloneSet's type and name into `scaleTargetRef`:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -293,7 +293,7 @@ Use SidecarSet for consistent sidecar injection across workloads.
 For comprehensive autoscaling strategies, see the [autoscaling best practices](https://openkruise.io/docs/best-practices/elastic-deployment).
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cloneset-hpa
@@ -308,7 +308,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      target:
+        type: Utilization
+        averageUtilization: 70
 ```
 
 ## Best Practices and Recommendations

--- a/docs/user-manuals/uniteddeployment.md
+++ b/docs/user-manuals/uniteddeployment.md
@@ -385,7 +385,7 @@ Horizontal Pod Autoscaler can support Custom Resource workload which has [scale 
 Since v1.5.0 you can HPA UnitedDeployment directly, as follows:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -394,10 +394,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-blog/2025-02-19-elastic-components.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2025-02-19-elastic-components.md
@@ -423,7 +423,7 @@ spec:
                     value: SERVERLESS
 ---
 # 结合 HPA 自动扩缩容
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: elastic-app-hpa
@@ -431,10 +431,12 @@ spec:
   minReplicas: 1
   maxReplicas: 100
   metrics:
-    - resource:
+    - type: Resource
+      resource:
         name: cpu
-        targetAverageUtilization: 2
-      type: Resource
+        target:
+          type: Utilization
+          averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/hpa-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/hpa-configuration.md
@@ -5,12 +5,14 @@ title: HPA configuration
 Kruise 中的 Workload，比如 CloneSet、Advanced StatefulSet、UnitedDeployment，都实现了 scale subresource。
 这表示它们都可以适配 HorizontalPodAutoscaler、PodDisruptionBudget 等原生操作。
 
+下文示例使用 `apiVersion: autoscaling/v2`（自 Kubernetes 1.23 起稳定）。较早的 `autoscaling/v2beta1` 与 `autoscaling/v2beta2` 已分别在 Kubernetes 1.25 与 1.26 中移除。对于资源类指标，请使用 `resource.target.type: Utilization` 与 `averageUtilization`，不要使用已弃用的 `targetAverageUtilization` 字段。
+
 ### 例子
 
 只需要将 CloneSet 的类型、名字写入 `scaleTargetRef` 即可：
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq.md
@@ -290,7 +290,7 @@ curl localhost:8080/metrics
 有关综合自动扩缩策略，请参阅[自动扩缩最佳实践](https://openkruise.io/docs/best-practices/elastic-deployment)。
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cloneset-hpa
@@ -305,7 +305,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      target:
+        type: Utilization
+        averageUtilization: 70
 ```
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/uniteddeployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/uniteddeployment.md
@@ -359,7 +359,7 @@ Horizontal Pod Autoscaler 能够支持包含 [scale subresource](https://kuberne
 从 kruise v1.5.0版本开始，你可以直接 HPA UnitedDeployment，如下：
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -368,10 +368,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/best-practices/hpa-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ Kruise 中的 Workload，比如 CloneSet、Advanced StatefulSet、UnitedDeployme
 只需要将 CloneSet 的类型、名字写入 `scaleTargetRef` 即可：
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/uniteddeployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/user-manuals/uniteddeployment.md
@@ -181,7 +181,7 @@ Horizontal Pod Autoscaler 能够支持包含 [scale subresource](https://kuberne
 从 kruise v1.5.0版本开始，你可以直接 HPA UnitedDeployment，如下：
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -190,10 +190,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/best-practices/hpa-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ Kruise 中的 Workload，比如 CloneSet、Advanced StatefulSet、UnitedDeployme
 只需要将 CloneSet 的类型、名字写入 `scaleTargetRef` 即可：
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/uniteddeployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/user-manuals/uniteddeployment.md
@@ -180,7 +180,7 @@ Horizontal Pod Autoscaler 能够支持包含 [scale subresource](https://kuberne
 从 kruise v1.5.0版本开始，你可以直接 HPA UnitedDeployment，如下：
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -189,10 +189,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/best-practices/hpa-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ Kruise 中的 Workload，比如 CloneSet、Advanced StatefulSet、UnitedDeployme
 只需要将 CloneSet 的类型、名字写入 `scaleTargetRef` 即可：
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/uniteddeployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/uniteddeployment.md
@@ -180,7 +180,7 @@ Horizontal Pod Autoscaler 能够支持包含 [scale subresource](https://kuberne
 从 kruise v1.5.0版本开始，你可以直接 HPA UnitedDeployment，如下：
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -189,10 +189,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/best-practices/hpa-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ Kruise 中的 Workload，比如 CloneSet、Advanced StatefulSet、UnitedDeployme
 只需要将 CloneSet 的类型、名字写入 `scaleTargetRef` 即可：
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/uniteddeployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/uniteddeployment.md
@@ -185,7 +185,7 @@ Horizontal Pod Autoscaler 能够支持包含 [scale subresource](https://kuberne
 从 kruise v1.5.0版本开始，你可以直接 HPA UnitedDeployment，如下：
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -194,10 +194,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/best-practices/hpa-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ Kruise 中的 Workload，比如 CloneSet、Advanced StatefulSet、UnitedDeployme
 只需要将 CloneSet 的类型、名字写入 `scaleTargetRef` 即可：
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/faq.md
@@ -290,7 +290,7 @@ curl localhost:8080/metrics
 有关综合自动扩缩策略，请参阅[自动扩缩最佳实践](https://openkruise.io/docs/best-practices/elastic-deployment)。
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cloneset-hpa
@@ -305,7 +305,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      target:
+        type: Utilization
+        averageUtilization: 70
 ```
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/uniteddeployment.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/uniteddeployment.md
@@ -359,7 +359,7 @@ Horizontal Pod Autoscaler 能够支持包含 [scale subresource](https://kuberne
 从 kruise v1.5.0版本开始，你可以直接 HPA UnitedDeployment，如下：
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -368,10 +368,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/versioned_docs/version-v1.5/best-practices/hpa-configuration.md
+++ b/versioned_docs/version-v1.5/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ which means they allow systems like HorizontalPodAutoscaler and PodDisruptionBud
 Just set the CloneSet's type and name into `scaleTargetRef`:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/versioned_docs/version-v1.5/user-manuals/uniteddeployment.md
+++ b/versioned_docs/version-v1.5/user-manuals/uniteddeployment.md
@@ -184,7 +184,7 @@ Horizontal Pod Autoscaler can support Custom Resource workload which has [scale 
 Since v1.5.0 you can HPA UnitedDeployment directly, as follows:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -193,10 +193,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/versioned_docs/version-v1.6/best-practices/hpa-configuration.md
+++ b/versioned_docs/version-v1.6/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ which means they allow systems like HorizontalPodAutoscaler and PodDisruptionBud
 Just set the CloneSet's type and name into `scaleTargetRef`:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/versioned_docs/version-v1.6/user-manuals/uniteddeployment.md
+++ b/versioned_docs/version-v1.6/user-manuals/uniteddeployment.md
@@ -184,7 +184,7 @@ Horizontal Pod Autoscaler can support Custom Resource workload which has [scale 
 Since v1.5.0 you can HPA UnitedDeployment directly, as follows:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -193,10 +193,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/versioned_docs/version-v1.7/best-practices/hpa-configuration.md
+++ b/versioned_docs/version-v1.7/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ which means they allow systems like HorizontalPodAutoscaler and PodDisruptionBud
 Just set the CloneSet's type and name into `scaleTargetRef`:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/versioned_docs/version-v1.7/user-manuals/uniteddeployment.md
+++ b/versioned_docs/version-v1.7/user-manuals/uniteddeployment.md
@@ -184,7 +184,7 @@ Horizontal Pod Autoscaler can support Custom Resource workload which has [scale 
 Since v1.5.0 you can HPA UnitedDeployment directly, as follows:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -193,10 +193,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/versioned_docs/version-v1.8/best-practices/hpa-configuration.md
+++ b/versioned_docs/version-v1.8/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ which means they allow systems like HorizontalPodAutoscaler and PodDisruptionBud
 Just set the CloneSet's type and name into `scaleTargetRef`:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/versioned_docs/version-v1.8/user-manuals/uniteddeployment.md
+++ b/versioned_docs/version-v1.8/user-manuals/uniteddeployment.md
@@ -190,7 +190,7 @@ Horizontal Pod Autoscaler can support Custom Resource workload which has [scale 
 Since v1.5.0 you can HPA UnitedDeployment directly, as follows:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -199,10 +199,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment

--- a/versioned_docs/version-v1.9/best-practices/hpa-configuration.md
+++ b/versioned_docs/version-v1.9/best-practices/hpa-configuration.md
@@ -10,7 +10,7 @@ which means they allow systems like HorizontalPodAutoscaler and PodDisruptionBud
 Just set the CloneSet's type and name into `scaleTargetRef`:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 # ...
 spec:

--- a/versioned_docs/version-v1.9/faq.md
+++ b/versioned_docs/version-v1.9/faq.md
@@ -293,7 +293,7 @@ Use SidecarSet for consistent sidecar injection across workloads.
 For comprehensive autoscaling strategies, see the [autoscaling best practices](https://openkruise.io/docs/best-practices/elastic-deployment).
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cloneset-hpa
@@ -308,7 +308,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      target:
+        type: Utilization
+        averageUtilization: 70
 ```
 
 ## Best Practices and Recommendations

--- a/versioned_docs/version-v1.9/user-manuals/uniteddeployment.md
+++ b/versioned_docs/version-v1.9/user-manuals/uniteddeployment.md
@@ -385,7 +385,7 @@ Horizontal Pod Autoscaler can support Custom Resource workload which has [scale 
 Since v1.5.0 you can HPA UnitedDeployment directly, as follows:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-hpa
@@ -394,10 +394,12 @@ spec:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - resource:
+  - type: Resource
+    resource:
       name: cpu
-      targetAverageUtilization: 2
-    type: Resource
+      target:
+        type: Utilization
+        averageUtilization: 2
   scaleTargetRef:
     apiVersion: apps.kruise.io/v1alpha1
     kind: UnitedDeployment


### PR DESCRIPTION
## Overview

This PR updates HPA documentation examples to use the stable `autoscaling/v2` API instead of the deprecated `autoscaling/v2beta1` and `autoscaling/v2beta2` versions, which were removed in newer Kubernetes releases.

## Changes made

* Replaced `autoscaling/v2beta1` and `autoscaling/v2beta2` with `autoscaling/v2`

* Updated deprecated `targetAverageUtilization` usage to the newer:

  ```yaml id="e0zv1h"
  resource:
    target:
      type: Utilization
      averageUtilization: ...
  ```

* Updated:

  * current docs,
  * versioned docs (`v1.5`–`v1.9`),
  * Chinese translation files,
  * and the elastic-components blog posts (EN + ZH)

* Added a short note in the current EN/ZH `hpa-configuration.md` explaining why `autoscaling/v2` is now used.

## Why this change

The older HPA API versions are no longer available in newer Kubernetes releases, so these examples can cause confusion or fail when copied into modern clusters. Updating the docs keeps the examples aligned with current Kubernetes standards and improves compatibility for users.

## Verification

* Verified all updated manifests use valid `autoscaling/v2` syntax
* Checked documentation rendering locally
* Confirmed examples are consistent across EN and ZH docs
