### PR TITLE
docs: fix broken cross-reference link in kruiseagents desktop sandbox guide

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/running-e2b-for-desktop.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/running-e2b-for-desktop.md
@@ -2,7 +2,7 @@
 
 该示例演示了如何通过 OpenKruise Agents 部署 [E2B](https://e2b.dev/) desktop 沙箱并通过 E2B SDK 进行调用。
 
-关于基础概念，请参考 [运行 E2B 代码执行沙箱](../code_interpreter)
+关于基础概念，请参考 [运行 E2B 代码执行沙箱](./running-e2b-for-code-interpreter)
 
 > 如果您在云平台上配置了安全组，请确保 6080 端口已打开，以便访问远程桌面。
 

--- a/kruiseagents/best-practices/running-e2b-for-desktop.md
+++ b/kruiseagents/best-practices/running-e2b-for-desktop.md
@@ -3,7 +3,7 @@
 This example demonstrates how to deploy an [E2B](https://e2b.dev/) desktop sandbox through OpenKruise Agents and invoke
 it via the E2B SDK.
 
-For basic concepts, please refer to [Running E2B Code Interpreter Sandbox](../code_interpreter)
+For basic concepts, please refer to [Running E2B Code Interpreter Sandbox](./running-e2b-for-code-interpreter)
 
 > If you have configured a security group on your cloud platform, please ensure that port 6080 is open to access the remote desktop.
 


### PR DESCRIPTION
## What this PR does / why we need it

  `kruiseagents/best-practices/running-e2b-for-desktop.md` line 6 referenced `../code_interpreter` which does not exist. The code interpreter guide lives at
  `best-practices/running-e2b-for-code-interpreter.md`, so the correct relative path from within `best-practices/` is `./running-e2b-for-code-interpreter`.
  Applied the same fix to the Chinese translation.

  ## Which issue(s) this PR fixes

 Fixes #335 

  ## Special notes for your reviewer

  Two files changed, one-line fix each:
  - `kruiseagents/best-practices/running-e2b-for-desktop.md` line 6
  - `i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/running-e2b-for-desktop.md` line 5
