### PR TITLE
fix: global UI polish, footer accessibility, and homepage accessibility fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,12 +205,10 @@ function getNextVersionName() {
                 href: 'https://kubernetes.slack.com/channels/openkruise',
               },
               {
-                label: 'DingTalk (GroupID: 23330762 )',
-                href: '.',
+                html: '<div class="footer__link" style="pointer-events: none; cursor: default; color: var(--ifm-footer-link-color); font-weight: 400;">DingTalk (GroupID: 23330762 )</div>',
               },
               {
-                label: 'WeChat (User: openkruise )',
-                href: '.',
+                html: '<div class="footer__link" style="pointer-events: none; cursor: default; color: var(--ifm-footer-link-color); font-weight: 400;">WeChat (User: openkruise )</div>',
               },
               {
                 label: 'Bi-week Meeting (APAC, Chinese)',
@@ -234,7 +232,7 @@ function getNextVersionName() {
         ],
         copyright: `
         <br />
-        <strong>© ${new Date().getFullYear()} The OpenKruise Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/"> Trademark Usage</a> page.</strong
+        <strong>© ${new Date().getFullYear()} The OpenKruise Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/"> Trademark Usage</a> page.</strong>
         `,
       },
       prism: {

--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -21,11 +21,11 @@
   },
   "link.item.label.DingTalk (GroupID: 23330762 )": {
     "message": "DingTalk (GroupID: 23330762 )",
-    "description": "The label of footer link with label=DingTalk (GroupID: 23330762 ) linking to ."
+    "description": "The label of footer text for DingTalk (GroupID: 23330762 )"
   },
   "link.item.label.WeChat (User: openkruise )": {
     "message": "WeChat (User: openkruise )",
-    "description": "The label of footer link with label=WeChat (User: openkruise ) linking to ."
+    "description": "The label of footer text for WeChat (User: openkruise )"
   },
   "link.item.label.Bi-week Meeting (APAC, Chinese)": {
     "message": "Bi-week Meeting (APAC, Chinese)",
@@ -40,7 +40,7 @@
     "description": "The label of footer link with label=Community Membership linking to https://github.com/openkruise/community/blob/master/community-membership.md"
   },
   "copyright": {
-    "message": "\n        <br />\n        <strong>© 2025 The OpenKruise Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href=\"https://www.linuxfoundation.org/trademark-usage/\"> Trademark Usage</a> page.</strong\n        ",
+    "message": "\n        <br />\n        <strong>© 2026 The OpenKruise Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href=\"https://www.linuxfoundation.org/trademark-usage/\"> Trademark Usage</a> page.</strong>\n        ",
     "description": "The footer copyright"
   }
 }

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -3,14 +3,14 @@ import Translate, { translate } from '@docusaurus/Translate';
 
 const features = [
   {
-    title: <><Translate>Advanced Workloads</Translate></>,
+    title: translate({message: 'Advanced Workloads'}),
     imgUrl: 'img/feature1.png',
     description: (
       <>
         <p>
           <Translate>
             OpenKruise contains a set of advanced workloads, such as CloneSet, Advanced StatefulSet, Advanced DaemonSet, BroadcastJob, SidecarSet and UnitedDeployment.
-            They brings more advanced abilities like in-place update, configurable scale/upgrade strategies, parallel operations.
+            They bring more advanced abilities like in-place update, configurable scale/upgrade strategies, parallel operations.
           </Translate>
             <br />
           <Translate>
@@ -23,7 +23,7 @@ const features = [
     ),
   },
   {
-    title: <><Translate>Advanced Day-2 Operations</Translate></>,
+    title: translate({message: 'Advanced Day-2 Operations'}),
     imgUrl: 'img/feature2.png',
     description: (
       <>
@@ -33,7 +33,7 @@ const features = [
           </Translate>
           <br />
           <Translate>
-            These operations includes image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more
+            These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more
           </Translate>
         </p>
       </>
@@ -41,7 +41,7 @@ const features = [
     reverse: true,
   },
   {
-    title: <><Translate>Battery Included Best Practices</Translate></>,
+    title: translate({message: 'Battery Included Best Practices'}),
     imgUrl: 'img/feature3.png',
     description: (
       <>
@@ -55,7 +55,7 @@ const features = [
           </Translate>
           <br />
           <Translate>
-           2. OpenKruise Games brings cloud native game server management such hot-update, and connects game servers to cloud service providers, matchmaking services, and O&M platforms. 
+           2. OpenKruise Games brings cloud native game server management such as hot-update, and connects game servers to cloud service providers, matchmaking services, and O&M platforms. 
           </Translate>
           <br />
           <Translate>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -112,8 +112,8 @@ const WhatIs = () => (
               <br />
               <br />
               <Translate>
-                Mostly features provided by OpenKruise are built primarily based on CRD extensions.
-                They can work in pure Kubernetes clusters without any other dependences.
+                Most features provided by OpenKruise are built primarily based on CRD extensions.
+                They can work in pure Kubernetes clusters without any other dependencies.
               </Translate>
             </small>
           </p>


### PR DESCRIPTION
### What this PR does:

This PR cleans up several UI and accessibility issues across the site to make it look more professional and polished.

**1. Footer & Copyright Fixes**

- Disabled broken links: Changed "DingTalk" and "WeChat" from broken clickable links into plain informational text. I matched the color and style exactly with the rest of the footer so it looks consistent but doesn't cause accidental page reloads.
- Fixed Copyright Tag: Fixed a broken HTML tag (</strong) in the footer that was causing rendering issues.
- Updated Year: Updated the copyright year to 2026 across both the English and Chinese versions of the site.

**2. Homepage Accessibility Fix**

- Fixed broken Alt Text: On the homepage, the image descriptions (alt text) were showing up as [object Object] in the code. I fixed this so that screen readers and search engines can correctly read the feature titles.

**3. Content Polish**

- Fixed Typos: Corrected a few grammar typos in the "What is OpenKruise?" and feature sections on the homepage to make the descriptions read more naturally.

### How to verify:

- Scroll to the bottom of any page and check that "DingTalk" and "WeChat" are no longer clickable but look exactly like the other links.
- Check that the copyright year is 2026.
- Inspect the homepage feature images to see that the alt tags now show actual text instead of [object Object].