### PR TITLE
docs: fix email typo in adopters and grammar in introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,7 +24,7 @@ Most features provided by OpenKruise are built primarily based on CRD extensions
     
     OpenKruise also provides high-level operation features to help you manage your applications for better efficiency, better resilience and cost-saving.
 
-    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even requires one or more containers in an running Pod to be restarted.
+    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even require one or more containers in a running Pod to be restarted.
 
 - **High-availability Protection**
 

--- a/src/data/adopters.js
+++ b/src/data/adopters.js
@@ -123,7 +123,7 @@ export const adopters = [
   {
     name: "FUTU",
     location: "Shenzhen, China",
-    contact: "chrisdeng@futunn.com.com",
+    contact: "chrisdeng@futunn.com",
     purpose: "Using Kruise for managing large-scale applications and sidecars."
   },
   {

--- a/versioned_docs/version-v1.7/introduction.md
+++ b/versioned_docs/version-v1.7/introduction.md
@@ -24,7 +24,7 @@ Most features provided by OpenKruise are built primarily based on CRD extensions
     
     OpenKruise also provides high-level operation features to help you manage your applications for better efficiency, better resilience and cost-saving.
 
-    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even requires one or more containers in an running Pod to be restarted.
+    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even require one or more containers in a running Pod to be restarted.
 
 - **High-availability Protection**
 

--- a/versioned_docs/version-v1.8/introduction.md
+++ b/versioned_docs/version-v1.8/introduction.md
@@ -24,7 +24,7 @@ Most features provided by OpenKruise are built primarily based on CRD extensions
     
     OpenKruise also provides high-level operation features to help you manage your applications for better efficiency, better resilience and cost-saving.
 
-    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even requires one or more containers in an running Pod to be restarted.
+    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even require one or more containers in a running Pod to be restarted.
 
 - **High-availability Protection**
 

--- a/versioned_docs/version-v1.9/introduction.md
+++ b/versioned_docs/version-v1.9/introduction.md
@@ -24,7 +24,7 @@ Most features provided by OpenKruise are built primarily based on CRD extensions
     
     OpenKruise also provides high-level operation features to help you manage your applications for better efficiency, better resilience and cost-saving.
 
-    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even requires one or more containers in an running Pod to be restarted.
+    These operations include image prewarming, container inplace restarts, workload distribution, pod probe & marking and many more. For example, you can use ImagePullJob to download any images on any nodes you want. Or you can even require one or more containers in a running Pod to be restarted.
 
 - **High-availability Protection**
 


### PR DESCRIPTION
### What this PR does:

This PR corrects minor content and grammar issues to improve document quality.

**1. Adopters List Fix**

- Fixed a typo in the contact field for FUTU in src/data/adopters.js where the email address incorrectly ended with .com.com.

**2. Introduction Grammar Fixes**

- Corrected grammar issues in the "What's OpenKruise" section:
- Changed an running Pod to a running Pod
- Changed even requires to even require

**These fixes were applied to:**

- the main introduction.md
- archived versions for v1.7
- archived versions for v1.8
- archived versions for v1.9