### PR TITLE
refactor: standardize navbar links to use absolute paths

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -151,7 +151,7 @@ function getNextVersionName() {
             position: 'right',
           },
           {
-            to: "docs/",
+            to: "/docs/",
             position: 'left',
             label: 'Kruise',
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -156,19 +156,19 @@ function getNextVersionName() {
             label: 'Kruise',
           },
           {
-            to: 'rollouts/introduction',
+            to: '/rollouts/introduction',
             position: 'left',
             label: 'Rollouts',
             activeBasePath: 'rollouts',
           },
           {
-            to: 'kruisegame/introduction',
+            to: '/kruisegame/introduction',
             position: 'left',
             label: 'Kruise-Game',
             activeBasePath: 'kruisegame',
           },
           {
-            to: 'kruiseagents/introduction',
+            to: '/kruiseagents/introduction',
             position: 'left',
             label: 'Kruise-Agents',
             activeBasePath: 'kruiseagents',


### PR DESCRIPTION
### Description:

This PR updates the to fields in the navbar configuration (docusaurus.config.js) to consistently use absolute paths (e.g., to: "/docs/" instead of to: "docs/").

**Context:** Initially, I thought the relative paths were causing a 404 issue on sub-product pages, but after digging deeper, I realized Docusaurus resolves these from the base URL anyway at build time.

Even though there was no runtime bug, I've updated the links for Kruise, Rollouts, Kruise-Game, and Kruise-Agents to explicitly use absolute paths. This matches the style of the other navbar items (like /blog and /docs/installation) and makes the code cleaner and less confusing for future contributors.

