### PR TITLE
blog: announce OpenKruise Agents v0.3.0 release (EN + ZH)

### DIFF
--- a/blog/2026-05-15-agents-v0.3.0.md
+++ b/blog/2026-05-15-agents-v0.3.0.md
@@ -1,0 +1,152 @@
+---
+slug: agents-v0.3.0
+title: "OpenKruise Agents v0.3.0: Rolling Updates, Multi-Tenancy, and Enhanced Observability"
+authors: [ abhisheksainimitawa ]
+tags: [ agents, release, sandbox, observability, multi-tenancy ]
+---
+
+We are excited to announce the release of **OpenKruise Agents v0.3.0**, the most feature-rich release since the project's inception. This release focuses on three major themes: **operational maturity** (rolling updates, in-place resource resize, richer metrics), **multi-tenancy** (team-scoped API keys, namespace isolation), and **ecosystem integrations** (custom CDP port for browser-use, E2B template APIs, MySQL-backed key storage). It also ships a significant number of bug fixes and stability improvements.
+
+<!--truncate-->
+
+## What is OpenKruise Agents?
+
+[OpenKruise Agents](https://openkruise.io/kruiseagents/introduction) is a Kubernetes-native sandbox orchestration system for AI Agent infrastructure. It enables sub-second sandbox delivery through pre-warming pools (`SandboxSet`), and provides an E2B-protocol-compatible API layer so existing AI Agent applications can adopt it without SDK changes.
+
+## Major Features in v0.3.0
+
+### 1. SandboxSet Rolling Updates
+
+`SandboxSet` now supports a **rolling update strategy** via the new `updateStrategy.maxUnavailable` field. When a SandboxSet template is updated, the controller rolls out the change gradually, keeping at most `maxUnavailable` warm sandboxes unavailable at any point. This prevents the warm pool from draining completely during updates, ensuring continuous availability for incoming sandbox claims.
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: my-pool
+spec:
+  replicas: 20
+  updateStrategy:
+    maxUnavailable: 5   # at most 5 warm sandboxes unavailable during rollout
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: my-image:v2
+```
+
+The `status` block now exposes `updatedReplicas` and `updatedAvailableReplicas` so you can track rollout progress via `kubectl get sbs`.
+
+### 2. In-Place CPU Resize for Warm Pool Sandboxes
+
+Warm pool sandboxes can now be resized **in place** without eviction and re-creation. This uses the Kubernetes in-place VPA mechanism and avoids the full pod restart cycle, preserving sandbox state and keeping the pool responsive.
+
+This is especially valuable for workloads where sandbox CPU requirements are known only at claim time — you can pre-warm with a base CPU allocation and resize during claiming rather than waiting for a new pod to schedule.
+
+### 3. Negative TTL — Never-Delete SandboxClaim
+
+`SandboxClaim` now supports a **negative TTL** (e.g., `ttlAfterCompleted: -1s`) to signal that a claimed sandbox should **never be automatically deleted**. Previously, achieving permanent sandboxes required workarounds at the application level. This is now a first-class field in the SandboxClaim spec.
+
+### 4. Team-Based Namespace Isolation and Team-Scoped API Keys
+
+v0.3.0 introduces a **multi-tenancy model** for platform teams running shared OpenKruise Agents clusters:
+
+- **Team namespaces**: Teams can be isolated into dedicated Kubernetes namespaces; sandbox operations are scoped to the team's namespace.
+- **Team-scoped API keys**: API keys are now associated with a team identity, enforcing that a key can only access sandboxes within its team boundary.
+
+This makes it safe to run multiple product teams on a single OpenKruise Agents cluster without cross-team sandbox access.
+
+### 5. Pluggable KeyStorage with MySQL Backend
+
+API key storage is now **pluggable**. In addition to the default in-memory store, v0.3.0 ships a production-ready **MySQL backend** for API key persistence. This allows key data to survive `sandbox-manager` restarts and enables horizontal scaling of the manager without key loss.
+
+Configuration is done via the Helm chart — set the storage backend and connection string in the `e2b` values section.
+
+### 6. SandboxMultiClusterNaming
+
+A new feature gate `SandboxMultiClusterNaming` embeds the **cluster ID** into sandbox names. This is essential for multi-cluster deployments where sandbox identifiers must be globally unique across clusters (e.g., when a shared E2B domain serves multiple Kubernetes clusters). Enable it via the feature gate flag on the sandbox-controller.
+
+### 7. Custom CDP Port for Browser-Use
+
+The `sandbox-manager` now supports configuring a **custom Chrome DevTools Protocol (CDP) port** for browser-use integrations. Previously the CDP port was hardcoded, making it impossible to run multiple browser sandboxes with different configurations on the same node. With this feature, each SandboxSet template can specify its own CDP port, removing that constraint.
+
+```python
+from e2b_desktop import Sandbox
+
+# Connect using a custom CDP port configured in the SandboxSet template
+desktop = Sandbox.create(template="browser-custom-port")
+```
+
+### 8. E2B Template List and Get APIs
+
+Two new E2B-compatible API endpoints are now available:
+
+- `GET /templates` — list all available SandboxSet templates
+- `GET /templates/{id}` — get details of a specific template
+
+These allow AI Agent orchestration frameworks to **discover available sandbox templates dynamically** at runtime, without needing a hardcoded list of template names. The response format follows the E2B protocol, so existing E2B tooling works out of the box.
+
+### 9. Enhanced Prometheus Observability
+
+v0.3.0 ships a comprehensive set of new Prometheus metrics across all three components:
+
+| Metric Category | What's New |
+|---|---|
+| Sandbox lifecycle | kube-state-metrics style per-sandbox state gauges |
+| Operation counters | Count of create/claim/pause/resume/delete operations |
+| Deletion duration | Histogram of how long sandbox deletion takes |
+| Resume type label | Label on resume metrics to distinguish warm vs. cold resumes |
+| Abnormal state detection | Gauge for sandboxes stuck in non-terminal states |
+| Manager internals | Queue depth, reconcile latency, claim worker utilization |
+
+Combined, these metrics give platform teams a complete picture of sandbox fleet health and are ready to wire into existing Grafana dashboards.
+
+### 10. Gateway Flow
+
+The `sandbox-gateway` component gains a **gateway flow** mode: traffic can now be shaped and routed at the gateway layer before reaching individual sandboxes. This lays the groundwork for future features like request-level load balancing and per-sandbox circuit breaking beyond the existing Envoy thresholds.
+
+---
+
+## Notable Bug Fixes
+
+| Fix | Impact |
+|---|---|
+| `maxUnavailable` percentage now uses ceiling rounding | Ensures at least 1 pod is always available with small pool sizes |
+| Pause/resume is now concurrency-safe under parallel requests | Fixes a race condition when multiple callers pause/resume the same sandbox |
+| CSI remounting correctly re-triggered on wakeup | Fixes data volume loss after sandbox resume |
+| `initContainers` included in in-place resize body | Prevents in-place VPA from failing when init containers have resource requests |
+| Stale `Upgrading` condition cleared on upgrade re-trigger | Fixes incorrect status reporting after back-to-back SandboxSet updates |
+| Lifecycle hook failure messages now include stdout/stderr | Dramatically improves debuggability of failing post-start hooks |
+| Reduced filesystem permissions for TLS certificates and keys | Security hardening |
+
+---
+
+## Upgrade Guide
+
+Please read the [CHANGELOG](https://github.com/openkruise/agents/blob/master/CHANGELOG.md) before upgrading. Key reminders:
+
+1. **Manually apply CRDs** before running `helm upgrade` — Helm does not auto-update CRDs. See [Installation](../kruiseagents/installation.md#upgrade-via-helm).
+2. Upgrade **Sandbox Controller first**, then **Sandbox Manager**.
+3. The `SandboxSet` rolling update feature is controlled via `updateStrategy.maxUnavailable` — review the [CHANGELOG](https://github.com/openkruise/agents/blob/master/CHANGELOG.md) for default behavior.
+4. MySQL-backed KeyStorage requires new Helm values; the default remains the in-memory store.
+
+---
+
+## New Contributors
+
+A warm welcome to the community members making their first contribution in this release:
+
+- [@liangxiaoping](https://github.com/liangxiaoping) — sandbox lifecycle metrics
+- [@BITLiutianyang](https://github.com/BITLiutianyang) — SandboxSet rolling update
+- [@KeyOfSpectator](https://github.com/KeyOfSpectator) — enhanced Prometheus observability
+- [@PRAteek-singHWY](https://github.com/PRAteek-singHWY) — TLS permission hardening
+- [@ajatshatru01](https://github.com/ajatshatru01) — SandboxSet volume claim template validation
+- [@Luckydog691](https://github.com/Luckydog691) — sandbox container image commit proposal
+
+---
+
+## What's Next
+
+The team's roadmap includes checkpoint-based sandbox forking for fast cloning, broader multi-cluster control plane support, and continued work on the MCP API layer. Follow the project at [github.com/openkruise/agents](https://github.com/openkruise/agents) and star it if you find it useful!
+
+**Full Changelog**: [v0.2.0...v0.3.0](https://github.com/openkruise/agents/compare/v0.2.0...v0.3.0)

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -39,3 +39,9 @@ Abner:
   title: Member of OpenKruise
   url: https://github.com/abner-1
   image_url: https://github.com/abner-1.png
+
+abhisheksainimitawa:
+  name: Abhishek Saini
+  title: Contributor of OpenKruise
+  url: https://github.com/abhisheksainimitawa
+  image_url: https://github.com/abhisheksainimitawa.png

--- a/i18n/zh/docusaurus-plugin-content-blog/2026-05-15-agents-v0.3.0.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2026-05-15-agents-v0.3.0.md
@@ -1,0 +1,152 @@
+---
+slug: agents-v0.3.0
+title: "OpenKruise Agents v0.3.0：滚动更新、多租户与增强可观测性"
+authors: [ abhisheksainimitawa ]
+tags: [ agents, release, sandbox, observability, multi-tenancy ]
+---
+
+我们很高兴地宣布 **OpenKruise Agents v0.3.0** 正式发布。这是该项目有史以来功能最丰富的版本。本次发布聚焦三大主题：**运营成熟度**（滚动更新、原地资源调整、更丰富的指标）、**多租户**（团队范围 API Key、命名空间隔离）以及**生态系统集成**（browser-use 自定义 CDP 端口、E2B 模板 API、MySQL 存储后端）。此外，本版本还包含大量缺陷修复和稳定性改进。
+
+<!--truncate-->
+
+## OpenKruise Agents 是什么？
+
+[OpenKruise Agents](https://openkruise.io/kruiseagents/introduction) 是一个面向 AI Agent 基础设施的 Kubernetes 原生沙箱编排系统。它通过预热池（`SandboxSet`）实现亚秒级沙箱交付，并提供与 E2B 协议兼容的 API 层，使现有 AI Agent 应用无需修改 SDK 即可接入。
+
+## v0.3.0 主要功能
+
+### 1. SandboxSet 滚动更新
+
+`SandboxSet` 现通过新增的 `updateStrategy.maxUnavailable` 字段支持**滚动更新策略**。当 SandboxSet 模板发生变更时，控制器会逐步推进更新，确保任意时刻不可用的预热沙箱数量不超过 `maxUnavailable` 的限制，从而避免预热池在更新期间被完全清空。
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: my-pool
+spec:
+  replicas: 20
+  updateStrategy:
+    maxUnavailable: 5   # 滚动更新期间最多 5 个预热沙箱不可用
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: my-image:v2
+```
+
+`status` 中新增 `updatedReplicas` 和 `updatedAvailableReplicas` 字段，可通过 `kubectl get sbs` 实时跟踪更新进度。
+
+### 2. 预热池沙箱原地 CPU 调整
+
+预热池中的沙箱现在可以**原地调整** CPU，无需驱逐和重建。该功能基于 Kubernetes 原地 VPA 机制，避免了完整的 Pod 重启流程，在保留沙箱状态的同时保持预热池的响应能力。
+
+对于只在声明时才能确定沙箱 CPU 需求的工作负载，这一功能尤为实用——可以按基础 CPU 配额进行预热，在声明阶段再进行调整，而无需等待新 Pod 完成调度。
+
+### 3. 负 TTL —— 永不删除的 SandboxClaim
+
+`SandboxClaim` 现在支持**负 TTL**（例如 `ttlAfterCompleted: -1s`），表示该声明的沙箱**永不自动删除**。此前，实现永久沙箱需要在应用层进行额外处理。现在这是 SandboxClaim spec 中的一等字段。
+
+### 4. 基于团队的命名空间隔离与团队范围 API Key
+
+v0.3.0 为共享 OpenKruise Agents 集群的平台团队引入了**多租户模型**：
+
+- **团队命名空间**：团队可被隔离到独立的 Kubernetes 命名空间中，沙箱操作被限定在团队命名空间范围内。
+- **团队范围 API Key**：API Key 现在与团队身份关联，确保一个 Key 只能访问其所属团队边界内的沙箱。
+
+这使得多个产品团队可以安全地共享同一个 OpenKruise Agents 集群，而不会产生跨团队的沙箱访问。
+
+### 5. 可插拔 KeyStorage 与 MySQL 后端
+
+API Key 存储现已支持**可插拔**。除默认的内存存储外，v0.3.0 提供了生产可用的 **MySQL 后端**，实现 API Key 的持久化存储，使 `sandbox-manager` 重启后 Key 数据不丢失，并支持 Manager 的水平扩展。
+
+通过 Helm Chart 进行配置——在 `e2b` values 区段中设置存储后端和连接字符串。
+
+### 6. SandboxMultiClusterNaming
+
+新特性门控 `SandboxMultiClusterNaming` 可将**集群 ID 嵌入沙箱名称**中。这对于多集群部署场景至关重要——当共享 E2B 域名服务于多个 Kubernetes 集群时，沙箱标识符必须在所有集群中全局唯一。通过 sandbox-controller 的特性门控参数启用此功能。
+
+### 7. browser-use 自定义 CDP 端口
+
+`sandbox-manager` 现在支持为 browser-use 集成配置**自定义 Chrome DevTools Protocol (CDP) 端口**。此前 CDP 端口是硬编码的，导致同一节点上无法运行具有不同配置的多个浏览器沙箱。现在每个 SandboxSet 模板可以指定独立的 CDP 端口，消除了这一限制。
+
+```python
+from e2b_desktop import Sandbox
+
+# 使用 SandboxSet 模板中配置的自定义 CDP 端口连接
+desktop = Sandbox.create(template="browser-custom-port")
+```
+
+### 8. E2B 模板列表与查询 API
+
+现在提供两个新的 E2B 兼容 API 端点：
+
+- `GET /templates` —— 列出所有可用的 SandboxSet 模板
+- `GET /templates/{id}` —— 查询指定模板的详情
+
+这使 AI Agent 编排框架能够在运行时**动态发现可用的沙箱模板**，无需在代码中硬编码模板名称列表。响应格式遵循 E2B 协议，现有 E2B 工具开箱即用。
+
+### 9. 增强的 Prometheus 可观测性
+
+v0.3.0 在三个组件中全面新增了 Prometheus 指标：
+
+| 指标类别 | 新增内容 |
+|---|---|
+| 沙箱生命周期 | kube-state-metrics 风格的单沙箱状态 Gauge |
+| 操作计数器 | 创建/声明/暂停/恢复/删除操作计数 |
+| 删除耗时 | 沙箱删除时长的 Histogram |
+| 恢复类型标签 | 恢复指标上区分冷热恢复的 Label |
+| 异常状态检测 | 卡在非终态的沙箱数量 Gauge |
+| Manager 内部指标 | 队列深度、协调延迟、声明 Worker 利用率 |
+
+这些指标共同为平台团队提供了沙箱集群健康状况的完整视图，可直接接入现有的 Grafana 看板。
+
+### 10. Gateway 流量模式
+
+`sandbox-gateway` 新增**网关流量模式**：流量现在可以在网关层进行整形和路由，然后再到达各个沙箱。这为未来的请求级负载均衡和超越现有 Envoy 阈值的单沙箱熔断功能奠定了基础。
+
+---
+
+## 重要缺陷修复
+
+| 修复项 | 影响 |
+|---|---|
+| `maxUnavailable` 百分比现使用向上取整 | 确保小预热池场景下始终至少有 1 个 Pod 可用 |
+| 暂停/恢复在并发请求下现已是并发安全的 | 修复多调用方同时暂停/恢复同一沙箱时的竞态条件 |
+| CSI 重挂载在唤醒阶段正确触发 | 修复沙箱恢复后数据卷丢失的问题 |
+| 原地 resize 请求体中包含 initContainers | 防止当 init 容器有资源请求时原地 VPA 失败 |
+| 重复触发升级时清除过期的 Upgrading 状态 | 修复连续 SandboxSet 更新后状态报告不正确的问题 |
+| 生命周期钩子失败消息中包含 stdout/stderr | 显著提升失败 post-start 钩子的调试效率 |
+| 降低 TLS 证书和密钥的文件系统权限 | 安全加固 |
+
+---
+
+## 升级指引
+
+升级前请阅读 [CHANGELOG](https://github.com/openkruise/agents/blob/master/CHANGELOG.md)。关键提醒：
+
+1. 执行 `helm upgrade` 前**手动应用 CRD**——Helm 不会自动更新 CRD。参见[安装文档](../kruiseagents/installation.md#upgrade-via-helm)。
+2. 升级顺序：先升级 **Sandbox Controller**，再升级 **Sandbox Manager**。
+3. `SandboxSet` 滚动更新通过 `updateStrategy.maxUnavailable` 控制——请参阅 [CHANGELOG](https://github.com/openkruise/agents/blob/master/CHANGELOG.md) 了解默认行为。
+4. MySQL 存储后端需要新的 Helm values；默认仍为内存存储。
+
+---
+
+## 新贡献者
+
+热烈欢迎在本次发布中首次贡献的社区成员：
+
+- [@liangxiaoping](https://github.com/liangxiaoping) — 沙箱生命周期指标
+- [@BITLiutianyang](https://github.com/BITLiutianyang) — SandboxSet 滚动更新
+- [@KeyOfSpectator](https://github.com/KeyOfSpectator) — 增强 Prometheus 可观测性
+- [@PRAteek-singHWY](https://github.com/PRAteek-singHWY) — TLS 权限加固
+- [@ajatshatru01](https://github.com/ajatshatru01) — SandboxSet 卷声明模板校验
+- [@Luckydog691](https://github.com/Luckydog691) — 沙箱容器镜像提交方案
+
+---
+
+## 未来展望
+
+团队路线图包括：基于 Checkpoint 的沙箱 Fork 快速克隆、更广泛的多集群控制面支持，以及 MCP API 层的持续演进。欢迎关注 [github.com/openkruise/agents](https://github.com/openkruise/agents)，如果觉得有用，请给项目点个 Star！
+
+**完整变更日志**：[v0.2.0...v0.3.0](https://github.com/openkruise/agents/compare/v0.2.0...v0.3.0)


### PR DESCRIPTION
## What

Adds a release announcement blog post for **OpenKruise Agents v0.3.0** (released 2026-05-15) in both English and Chinese. Also adds `abhisheksainimitawa` to `blog/authors.yml`.

## Why

The [v0.3.0 release](https://github.com/openkruise/agents/releases/tag/v0.3.0) was published today but has no corresponding blog post on the website. The last blog post is from February 2025 (~15 months gap). A release announcement helps users discover new features and understand the upgrade path.

## Content Summary

The post covers 10 major features from the changelog:

| Feature | Highlight |
|---|---|
| SandboxSet Rolling Updates | `updateStrategy.maxUnavailable` for controlled rollouts |
| In-Place CPU Resize | Resize warm pool sandboxes without pod eviction |
| Negative TTL | Never-delete SandboxClaim as a first-class field |
| Team Multi-Tenancy | Namespace isolation + team-scoped API keys |
| Pluggable KeyStorage | MySQL backend for API key persistence |
| SandboxMultiClusterNaming | Cluster ID embedded in sandbox names |
| Custom CDP Port | Per-template CDP port for browser-use |
| E2B Template APIs | `GET /templates` list and get endpoints |
| Enhanced Observability | Full Prometheus metrics across all 3 components |
| Gateway Flow | Traffic shaping at the gateway layer |

Also includes: notable bug fix table, upgrade guide, and new contributor shoutouts.

## Checklist

- [x] Content derived entirely from the official [v0.3.0 CHANGELOG](https://github.com/openkruise/agents/compare/v0.2.0...v0.3.0)
- [x] No claims made about default values that aren't confirmed in the changelog
- [x] Chinese translation covers all sections in the English version, assisted by cluade sonnet 4.6 for translation
- [x] Frontmatter format matches existing blog posts (`slug`, `title`, `authors`, `tags`)
- [x] Author key `abhisheksainimitawa` added to `blog/authors.yml`
- [x] DCO sign-off present

/cc @furykerry @zmberg @ls-2018 