### PR TITLE
Fixed broken links in introduction page

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/introduction.md
@@ -65,5 +65,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).


### PR DESCRIPTION
## What
Fixed broken "What's Next" links in the English and Chinese introduction 
pages by replacing incorrect `./docs/` prefixes with correct relative file paths 
for Docusaurus routing.

## Why
The links used a `./docs/` relative prefix which Docusaurus resolves as a 
file-system path, looking for `docs/docs/installation.md` which does not exist, 
causing 404s for users navigating from the introduction page.

## Changes
- `docs/introduction.md` — replaced `./docs/` prefixes with relative file paths (`./installation.md`, `./core-concepts/architecture.md`)
- `i18n/zh/docusaurus-plugin-content-docs/current/introduction.md` — same fix applied to Chinese counterpart

## Root Cause
Docusaurus resolves `./docs/` as a file-system path, looking for 
`docs/docs/installation.md` which does not exist. Using relative `.md` 
file paths lets Docusaurus resolve the correct versioned URL at build time.

## Test Plan
- [ ] "What's Next" links on the English introduction page navigate correctly
- [ ] "What's Next" links on the Chinese introduction page navigate correctly
- [ ] No other pages are broken

/cc @furykerry @zmberg 