### PR TITLE
feat: Document Agent PoC — automated release blog generation and freshness checker

### DIFF
--- a/.github/workflows/doc-agent.yml
+++ b/.github/workflows/doc-agent.yml
@@ -1,0 +1,37 @@
+name: Documentation Agent
+
+# Runs the OpenKruise Document Agent that checks sub-project releases,
+# evaluates documentation freshness, and regenerates release blog posts.
+
+on:
+  # Every Monday at 09:00 UTC.
+  schedule:
+    - cron: "0 9 * * 1"
+  # Allow running it manually from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  doc-agent:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run document agent
+        run: python scripts/doc_agent.py
+
+      - name: Upload generated artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc-agent-output
+          path: agent-output/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ yarn-error.log*
 
 .github/workflows/game/go.*
 .github/workflows/kruise/go.*
-.github/workflows/rollouts/go.*
+.github/workflows/rollouts/go.*__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,8 @@ yarn-error.log*
 
 .github/workflows/game/go.*
 .github/workflows/kruise/go.*
-.github/workflows/rollouts/go.*__pycache__/
+.github/workflows/rollouts/go.*
+
+# Python (doc agent)
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This was built as a proof-of-concept for an LFX mentorship application.
 | 3 | Evaluates **documentation freshness** — a release older than 30 days is flagged `STALE`. |
 | 4 | Auto-generates a Docusaurus-compatible blog post for each sub-project's latest release. |
 | 5 | Writes a consolidated freshness report. |
-| 6 | **Evaluates the existing `docs/` folder** — broken links, stale pages, and TODO/FIXME/XXX markers — and writes a documentation evaluation report. |
+| 6 | **Evaluates the existing `docs/` folder** — broken internal links, broken external links (live HTTP check), stale pages, and TODO/FIXME/XXX markers — and writes a documentation evaluation report. |
 
 Full pipeline: **fetch releases → generate blogs → evaluate docs → write all
 reports.**
@@ -36,7 +36,9 @@ To track more, add an entry to `SUB_PROJECTS` in `scripts/doc_agent.py`.
   `datetime`, `importlib` for the main agent; `subprocess` for the
   staleness checker's `git log` calls).
 - **[`requests`](https://pypi.org/project/requests/)** — the only third-party
-  dependency, used for GitHub API calls.
+  runtime dependency, used for GitHub API calls and the external-link check.
+- **[`pytest`](https://pypi.org/project/pytest/)** — test-only dependency
+  (not needed to run the agent). See [Testing](#testing).
 - **GitHub Releases API** — public endpoints, no authentication token
   required (subject to GitHub's unauthenticated rate limit of 60 req/hour,
   well within the agent's 4 requests per run).
@@ -46,6 +48,9 @@ To track more, add an entry to `SUB_PROJECTS` in `scripts/doc_agent.py`.
 ```bash
 pip install requests
 python scripts/doc_agent.py
+
+# Offline / CI: skip the live external-link HTTP checks
+SKIP_EXTERNAL_LINKS=1 python scripts/doc_agent.py
 ```
 
 ## Documentation evaluation layer
@@ -59,11 +64,12 @@ package:
 scripts/
 ├── doc_agent.py              # main agent (entry point)
 └── doc_agent/
-    ├── evaluate.py           # runs all checkers, writes the report
+    ├── evaluate.py            # runs all checkers, writes the report
     └── checkers/
-        ├── broken_links.py   # empty links + links to missing local files
-        ├── staleness.py      # pages whose last git commit is > 180 days old
-        └── todo_scan.py      # TODO / FIXME / XXX markers in docs
+        ├── broken_links.py    # empty links + links to missing local files
+        ├── external_links.py  # live HTTP check of external http(s) links
+        ├── staleness.py       # pages whose last git commit is > 180 days old
+        └── todo_scan.py       # TODO / FIXME / XXX markers in docs
 ```
 
 Each checker exposes one uniform entry point — `run(docs_dir: str) ->
@@ -78,14 +84,37 @@ python scripts/doc_agent/evaluate.py                      # full report
 | Checker | Detects |
 | ------- | ------- |
 | `broken_links` | `[text]()` (empty) and `[text](./missing.md)` (link to a non-existent local file). External/anchor/site-absolute links are skipped to avoid false positives. |
+| `external_links` | External `http(s)` links that are unreachable: HEAD request (10s timeout, redirects followed, retries GET on 403/405), reported on non-2xx or timeout. Rate-limited to 1 req/s; each unique URL checked once. Set `SKIP_EXTERNAL_LINKS` to skip (offline/CI). |
 | `staleness` | Pages whose **last git commit** is more than 180 days old (uses `git log` via `subprocess`, not filesystem mtime, which a fresh checkout would reset). |
-| `todo_scan` | `TODO`, `FIXME`, `XXX` markers (case-sensitive, word-boundary) with surrounding context. |
+| `todo_scan` | `TODO` / `FIXME` (case-insensitive) and `XXX` (upper-case only) markers, word-boundary, with surrounding context. Code fences and `context.TODO()`-style call forms are skipped. |
 
-`evaluate.py` aggregates all three into
-`agent-output/docs-evaluation-report.md`. Note: `scripts/doc_agent.py` (file)
-and `scripts/doc_agent/` (package) share a base name, so the main agent loads
-`evaluate.py` by file path via `importlib` rather than a normal import, which
-sidesteps that ambiguity.
+`evaluate.py` aggregates all four into
+`agent-output/docs-evaluation-report.md` (a Summary table plus one section
+per checker). Note: `scripts/doc_agent.py` (file) and `scripts/doc_agent/`
+(package) share a base name, so the main agent loads `evaluate.py` by file
+path via `importlib` rather than a normal import, which sidesteps that
+ambiguity.
+
+## Testing
+
+Unit tests for the checkers live in [`tests/`](tests/) and use `pytest`
+with `unittest.mock` (git calls are mocked — no network, no git needed).
+The whole suite runs in well under a second.
+
+```bash
+pip install pytest
+python -m pytest tests/          # or: python -m pytest tests/ -q
+```
+
+| Test file | Covers |
+| --------- | ------ |
+| `test_broken_links.py` | empty hrefs, missing local files, extensionless resolution, skipping external/anchor/site-absolute links, images-not-links, line numbers. |
+| `test_staleness.py` | mocked `git` output for fresh vs. stale files, the strict `> 180` boundary, no-history files, and "not a git repo". |
+| `test_todo_scan.py` | upper-case detection, TODO/FIXME case-insensitivity, `XXX` case-sensitivity, context capture, code-fence / call-form skipping, multiple markers per line. |
+
+The live `external_links` checker is intentionally **not** unit-tested
+against the network; run it offline via `SKIP_EXTERNAL_LINKS=1`, or point it
+at a single file ad hoc: `python scripts/doc_agent/checkers/external_links.py docs`.
 
 ## Outputs
 
@@ -154,6 +183,8 @@ review.
 4. `generate_blog_post()` / `write_freshness_report()` — render the
    Docusaurus markdown and the report table.
 5. `run_docs_evaluation()` — loads `scripts/doc_agent/evaluate.py` by path,
-   which runs the three checkers against `docs/` and writes
+   which runs the four checkers against `docs/` and writes
    `agent-output/docs-evaluation-report.md`. This step always runs, even if
-   a release fetch failed, so the docs report is still produced.
+   a release fetch failed, so the docs report is still produced. The
+   external-link checker self-skips when `SKIP_EXTERNAL_LINKS` is set, and
+   the report shows that section as *skipped* rather than "0 issues".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ This was built as a proof-of-concept for an LFX mentorship application.
 | 3 | Evaluates **documentation freshness** — a release older than 30 days is flagged `STALE`. |
 | 4 | Auto-generates a Docusaurus-compatible blog post for each sub-project's latest release. |
 | 5 | Writes a consolidated freshness report. |
+| 6 | **Evaluates the existing `docs/` folder** — broken links, stale pages, and TODO/FIXME/XXX markers — and writes a documentation evaluation report. |
+
+Full pipeline: **fetch releases → generate blogs → evaluate docs → write all
+reports.**
 
 ## Tracked sub-projects
 
@@ -28,8 +32,9 @@ To track more, add an entry to `SUB_PROJECTS` in `scripts/doc_agent.py`.
 
 ## Tools & dependencies
 
-- **Python 3.9+** (uses standard library: `json`, `os`, `re`, `sys`,
-  `textwrap`, `datetime`).
+- **Python 3.9+** (standard library only: `json`, `os`, `re`, `sys`,
+  `datetime`, `importlib` for the main agent; `subprocess` for the
+  staleness checker's `git log` calls).
 - **[`requests`](https://pypi.org/project/requests/)** — the only third-party
   dependency, used for GitHub API calls.
 - **GitHub Releases API** — public endpoints, no authentication token
@@ -43,6 +48,45 @@ pip install requests
 python scripts/doc_agent.py
 ```
 
+## Documentation evaluation layer
+
+In addition to generating blog posts from upstream releases, the agent
+**evaluates the documentation already in this repo's `docs/` folder**. This
+is a separate, pluggable layer that lives in the `scripts/doc_agent/`
+package:
+
+```
+scripts/
+├── doc_agent.py              # main agent (entry point)
+└── doc_agent/
+    ├── evaluate.py           # runs all checkers, writes the report
+    └── checkers/
+        ├── broken_links.py   # empty links + links to missing local files
+        ├── staleness.py      # pages whose last git commit is > 180 days old
+        └── todo_scan.py      # TODO / FIXME / XXX markers in docs
+```
+
+Each checker exposes one uniform entry point — `run(docs_dir: str) ->
+list[dict]` — and is fully independent, so checkers can be run or unit-tested
+in isolation:
+
+```bash
+python scripts/doc_agent/checkers/broken_links.py docs   # JSON to stdout
+python scripts/doc_agent/evaluate.py                      # full report
+```
+
+| Checker | Detects |
+| ------- | ------- |
+| `broken_links` | `[text]()` (empty) and `[text](./missing.md)` (link to a non-existent local file). External/anchor/site-absolute links are skipped to avoid false positives. |
+| `staleness` | Pages whose **last git commit** is more than 180 days old (uses `git log` via `subprocess`, not filesystem mtime, which a fresh checkout would reset). |
+| `todo_scan` | `TODO`, `FIXME`, `XXX` markers (case-sensitive, word-boundary) with surrounding context. |
+
+`evaluate.py` aggregates all three into
+`agent-output/docs-evaluation-report.md`. Note: `scripts/doc_agent.py` (file)
+and `scripts/doc_agent/` (package) share a base name, so the main agent loads
+`evaluate.py` by file path via `importlib` rather than a normal import, which
+sidesteps that ambiguity.
+
 ## Outputs
 
 All generated files are written to `agent-output/` (kept separate from the
@@ -54,8 +98,9 @@ agent-output/
 │   ├── <date>-kruise-<tag>.md
 │   ├── <date>-rollouts-<tag>.md
 │   ├── <date>-kruise-game-<tag>.md
-│   └── <date>-kruise-rollout-<tag>.md
-└── freshness-report.md
+│   └── <date>-kruise-rollout-api-<tag>.md
+├── freshness-report.md
+└── docs-evaluation-report.md
 ```
 
 ### Blog post format
@@ -108,3 +153,7 @@ review.
    paragraph so the post still has real content.
 4. `generate_blog_post()` / `write_freshness_report()` — render the
    Docusaurus markdown and the report table.
+5. `run_docs_evaluation()` — loads `scripts/doc_agent/evaluate.py` by path,
+   which runs the three checkers against `docs/` and writes
+   `agent-output/docs-evaluation-report.md`. This step always runs, even if
+   a release fetch failed, so the docs report is still produced.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# OpenKruise Document Agent
+
+An intelligent documentation agent for the OpenKruise website. It keeps the
+documentation site in sync with upstream sub-project releases by checking
+GitHub for new releases, scoring how fresh the docs are, and auto-drafting
+release blog posts.
+
+This was built as a proof-of-concept for an LFX mentorship application.
+
+## What it does
+
+| Step | Action |
+| ---- | ------ |
+| 1 | Fetches the latest release for each tracked OpenKruise sub-project from the public GitHub Releases API. |
+| 2 | Extracts the latest release tag, publish date, and changelog body. |
+| 3 | Evaluates **documentation freshness** — a release older than 30 days is flagged `STALE`. |
+| 4 | Auto-generates a Docusaurus-compatible blog post for each sub-project's latest release. |
+| 5 | Writes a consolidated freshness report. |
+
+## Tracked sub-projects
+
+- [`openkruise/kruise`](https://github.com/openkruise/kruise)
+- [`openkruise/rollouts`](https://github.com/openkruise/rollouts)
+- [`openkruise/kruise-game`](https://github.com/openkruise/kruise-game)
+- [`openkruise/kruise-rollout-api`](https://github.com/openkruise/kruise-rollout-api)
+
+To track more, add an entry to `SUB_PROJECTS` in `scripts/doc_agent.py`.
+
+## Tools & dependencies
+
+- **Python 3.9+** (uses standard library: `json`, `os`, `re`, `sys`,
+  `textwrap`, `datetime`).
+- **[`requests`](https://pypi.org/project/requests/)** — the only third-party
+  dependency, used for GitHub API calls.
+- **GitHub Releases API** — public endpoints, no authentication token
+  required (subject to GitHub's unauthenticated rate limit of 60 req/hour,
+  well within the agent's 4 requests per run).
+
+## How to run
+
+```bash
+pip install requests
+python scripts/doc_agent.py
+```
+
+## Outputs
+
+All generated files are written to `agent-output/` (kept separate from the
+live `blog/` directory so a human can review before publishing):
+
+```
+agent-output/
+├── blogs/
+│   ├── <date>-kruise-<tag>.md
+│   ├── <date>-rollouts-<tag>.md
+│   ├── <date>-kruise-game-<tag>.md
+│   └── <date>-kruise-rollout-<tag>.md
+└── freshness-report.md
+```
+
+### Blog post format
+
+Each generated post uses Docusaurus blog front matter:
+
+```markdown
+---
+title: "OpenKruise Kruise v1.x.x Released"
+date: 2026-05-18
+author: OpenKruise Community
+tags: [kruise, release]
+---
+
+## What's New in vX.X.X
+
+- ... (top 5 highlights parsed from the GitHub release body)
+
+For the full changelog, see the [release notes](<github release url>).
+```
+
+### Exit codes
+
+- `0` — all sub-projects fetched and processed successfully.
+- `1` — one or more sub-projects could not be fetched (the run still
+  produces output for the successful ones; CI surfaces the failure).
+
+## Automation
+
+The agent runs via GitHub Actions
+([`.github/workflows/doc-agent.yml`](.github/workflows/doc-agent.yml)):
+
+- **Scheduled:** every Monday at 09:00 UTC (`cron: "0 9 * * 1"`).
+- **Manual:** via `workflow_dispatch` from the Actions tab.
+
+Generated files are uploaded as the `doc-agent-output` build artifact for
+review.
+
+## How it works internally
+
+1. `fetch_latest_release()` — calls the GitHub Releases API per repo, skips
+   drafts, and picks the newest by `published_at` (not relying solely on API
+   ordering). Network/JSON errors are caught per-repo so one bad repo does
+   not abort the run.
+2. `evaluate_freshness()` — compares the release date to "now" (UTC) and
+   returns days-since-release plus a `FRESH`/`STALE` status.
+3. `extract_highlights()` — parses the release body for markdown bullet
+   points, strips links/formatting, and keeps the top 5. When a release has
+   no bullets, `extract_prose_summary()` falls back to the first meaningful
+   paragraph so the post still has real content.
+4. `generate_blog_post()` / `write_freshness_report()` — render the
+   Docusaurus markdown and the report table.

--- a/agent-output/blogs/2025-02-06-kruise-rollout-api-v0.6.0.md
+++ b/agent-output/blogs/2025-02-06-kruise-rollout-api-v0.6.0.md
@@ -1,0 +1,12 @@
+---
+title: "OpenKruise Kruise-Rollout-API v0.6.0 Released"
+date: 2025-02-06
+author: OpenKruise Community
+tags: [kruise-rollout-api, release]
+---
+
+## What's New in v0.6.0
+
+sync api from rollouts v0.6.0
+
+For the full changelog, see the [release notes](https://github.com/openkruise/kruise-rollout-api/releases/tag/v0.6.0).

--- a/agent-output/blogs/2025-07-21-kruise-game-v1.0.0.md
+++ b/agent-output/blogs/2025-07-21-kruise-game-v1.0.0.md
@@ -1,0 +1,12 @@
+---
+title: "OpenKruise Kruise-Game v1.0.0 Released"
+date: 2025-07-21
+author: OpenKruise Community
+tags: [kruise-game, release]
+---
+
+## What's New in v1.0.0
+
+Please check the CHANGELOG for a list of changes.
+
+For the full changelog, see the [release notes](https://github.com/openkruise/kruise-game/releases/tag/v1.0.0).

--- a/agent-output/blogs/2025-12-22-rollouts-v0.6.2.md
+++ b/agent-output/blogs/2025-12-22-rollouts-v0.6.2.md
@@ -1,0 +1,13 @@
+---
+title: "OpenKruise Rollouts v0.6.2 Released"
+date: 2025-12-22
+author: OpenKruise Community
+tags: [rollouts, release]
+---
+
+## What's New in v0.6.2
+
+- Fixed issue where partition deployments got stuck. (#307,@AiRanthem)
+- Compatibility with Karmada when the MutateWebhook newObj UID is empty during workload update. (#319,@ivan-cai)
+
+For the full changelog, see the [release notes](https://github.com/openkruise/rollouts/releases/tag/v0.6.2).

--- a/agent-output/blogs/2026-02-25-kruise-v1.8.3.md
+++ b/agent-output/blogs/2026-02-25-kruise-v1.8.3.md
@@ -1,0 +1,12 @@
+---
+title: "OpenKruise Kruise v1.8.3 Released"
+date: 2026-02-25
+author: OpenKruise Community
+tags: [kruise, release]
+---
+
+## What's New in v1.8.3
+
+- restrict host field in probe (#2309) by @furykerry in https://github.com/openkruise/kruise/pull/2372
+
+For the full changelog, see the [release notes](https://github.com/openkruise/kruise/releases/tag/v1.8.3).

--- a/agent-output/docs-evaluation-report.md
+++ b/agent-output/docs-evaluation-report.md
@@ -1,6 +1,6 @@
 # OpenKruise Documentation Evaluation Report
 
-_Generated on 2026-05-17 19:47 UTC by the OpenKruise Document Agent._
+_Generated on 2026-05-17 21:10 UTC by the OpenKruise Document Agent._
 
 **Scanned:** `docs/` — 39 Markdown files
 
@@ -8,17 +8,31 @@ _Generated on 2026-05-17 19:47 UTC by the OpenKruise Document Agent._
 
 | Check | Issues |
 | --- | --- |
-| 🔗 Broken links | 3 |
+| 🔗 Broken internal links | 3 |
+| 🌐 Broken external links | 6 |
 | 🕒 Stale docs (> 180 days) | 20 |
 | 📝 TODO / FIXME / XXX | 0 |
 
-## 🔗 Broken Links (3)
+## 🔗 Broken Internal Links (3)
 
 | File | Line | Link Text | Issue |
 | --- | --- | --- | --- |
 | docs/introduction.md | 59 | install OpenKruise | missing_file |
 | docs/introduction.md | 60 | Architecture | missing_file |
 | docs/user-manuals/sidecarset.md | 439 | Dynamic Resource Injection with SidecarSet | missing_file |
+
+## 🌐 Broken External Links (6)
+
+_HEAD request, 10s timeout, redirects followed, rate-limited to 1 req/s._
+
+| File | Line | URL | Status |
+| --- | --- | --- | --- |
+| docs/user-manuals/sidecarset.md | 1087 | https://help.aliyun.com/document_detail/193804.html | error: ConnectionError |
+| docs/cli-tool/kubectl-plugin.md | 9 | https://krew.sigs.k8s.io/ | timeout |
+| docs/installation.md | 30 | https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd/ | 404 |
+| docs/best-practices/log-container-sidecarset.md | 210 | https://openkruise.io/docs/next/core-concepts/inplace-update/ | 404 |
+| docs/best-practices/ci-pipeline-image-predownload.md | 14 | https://openkruise.io/docs/user-manuals/imagepulljob/ | 404 |
+| docs/best-practices/log-container-sidecarset.md | 46 | https://openkruise.io/docs/user-manuals/sidecarset/ | 404 |
 
 ## 🕒 Stale Documentation (20)
 

--- a/agent-output/docs-evaluation-report.md
+++ b/agent-output/docs-evaluation-report.md
@@ -1,0 +1,52 @@
+# OpenKruise Documentation Evaluation Report
+
+_Generated on 2026-05-17 19:47 UTC by the OpenKruise Document Agent._
+
+**Scanned:** `docs/` — 39 Markdown files
+
+## Summary
+
+| Check | Issues |
+| --- | --- |
+| 🔗 Broken links | 3 |
+| 🕒 Stale docs (> 180 days) | 20 |
+| 📝 TODO / FIXME / XXX | 0 |
+
+## 🔗 Broken Links (3)
+
+| File | Line | Link Text | Issue |
+| --- | --- | --- | --- |
+| docs/introduction.md | 59 | install OpenKruise | missing_file |
+| docs/introduction.md | 60 | Architecture | missing_file |
+| docs/user-manuals/sidecarset.md | 439 | Dynamic Resource Injection with SidecarSet | missing_file |
+
+## 🕒 Stale Documentation (20)
+
+_Files whose last git commit is more than 180 days old._
+
+| File | Last Modified | Days Since |
+| --- | --- | --- |
+| docs/core-concepts/architecture.md | 2021-09-24 | 1696 |
+| docs/best-practices/hpa-configuration.md | 2021-09-24 | 1696 |
+| docs/best-practices/gitops-with-kruise.md | 2022-12-06 | 1258 |
+| docs/cli-tool/kustomize-plugin.md | 2023-09-23 | 967 |
+| docs/developer-manuals/java-client.md | 2023-09-23 | 967 |
+| docs/developer-manuals/other-languages.md | 2023-09-23 | 967 |
+| docs/user-manuals/containerrecreaterequest.md | 2023-09-23 | 967 |
+| docs/user-manuals/resourcedistribution.md | 2023-09-23 | 967 |
+| docs/best-practices/acronjob+broadcastjob.md | 2023-09-23 | 967 |
+| docs/best-practices/ci-pipeline-image-predownload.md | 2023-09-23 | 967 |
+| docs/best-practices/cloneset-lifecycle.md | 2023-09-23 | 967 |
+| docs/best-practices/elastic-deployment.md | 2023-09-23 | 967 |
+| docs/cli-tool/kustomize-schema-generator.md | 2023-10-27 | 933 |
+| docs/best-practices/log-container-sidecarset.md | 2024-06-20 | 696 |
+| docs/user-manuals/jobsidecarterminator.md | 2025-01-06 | 496 |
+| docs/developer-manuals/go-client.md | 2025-04-02 | 410 |
+| docs/user-manuals/podprobemarker.md | 2025-04-02 | 410 |
+| docs/operator-manuals/availability.md | 2025-07-07 | 314 |
+| docs/user-manuals/containerlaunchpriority.md | 2025-07-09 | 312 |
+| docs/faq.md | 2025-07-29 | 292 |
+
+## 📝 TODO / FIXME / XXX Markers (0)
+
+✅ No TODO/FIXME/XXX markers found.

--- a/agent-output/freshness-report.md
+++ b/agent-output/freshness-report.md
@@ -1,6 +1,6 @@
 # OpenKruise Documentation Freshness Report
 
-_Generated on 2026-05-17 19:07 UTC by the OpenKruise Document Agent._
+_Generated on 2026-05-17 19:47 UTC by the OpenKruise Document Agent._
 
 A release is flagged **STALE** when its publish date is more than 30 days old.
 

--- a/agent-output/freshness-report.md
+++ b/agent-output/freshness-report.md
@@ -1,0 +1,12 @@
+# OpenKruise Documentation Freshness Report
+
+_Generated on 2026-05-17 19:07 UTC by the OpenKruise Document Agent._
+
+A release is flagged **STALE** when its publish date is more than 30 days old.
+
+| Sub-Project | Latest Version | Release Date | Days Since Release | Status |
+| ----------- | -------------- | ------------ | ------------------ | ------ |
+| Kruise | v1.8.3 | 2026-02-25 | 81 | 🔴 STALE |
+| Rollouts | v0.6.2 | 2025-12-22 | 146 | 🔴 STALE |
+| Kruise-Game | v1.0.0 | 2025-07-21 | 300 | 🔴 STALE |
+| Kruise-Rollout-API | v0.6.0 | 2025-02-06 | 465 | 🔴 STALE |

--- a/agent-output/freshness-report.md
+++ b/agent-output/freshness-report.md
@@ -1,6 +1,6 @@
 # OpenKruise Documentation Freshness Report
 
-_Generated on 2026-05-17 19:47 UTC by the OpenKruise Document Agent._
+_Generated on 2026-05-17 21:10 UTC by the OpenKruise Document Agent._
 
 A release is flagged **STALE** when its publish date is more than 30 days old.
 

--- a/scripts/doc_agent.py
+++ b/scripts/doc_agent.py
@@ -14,6 +14,11 @@ What it does
    days is flagged as STALE).
 4. Auto-generates a Docusaurus-compatible blog post for each sub-project.
 5. Writes a consolidated freshness report.
+6. Evaluates the existing `docs/` folder (broken links, stale pages,
+   TODO/FIXME markers) and writes a documentation evaluation report.
+
+Full pipeline: fetch releases -> generate blogs -> evaluate docs ->
+write all reports.
 
 Dependencies: Python standard library + `requests`.
 
@@ -23,6 +28,7 @@ Run:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -52,6 +58,14 @@ STALE_AFTER_DAYS = 30
 OUTPUT_ROOT = "agent-output"
 BLOG_DIR = os.path.join(OUTPUT_ROOT, "blogs")
 FRESHNESS_REPORT = os.path.join(OUTPUT_ROOT, "freshness-report.md")
+EVAL_REPORT = os.path.join(OUTPUT_ROOT, "docs-evaluation-report.md")
+
+# Documentation evaluation. Paths are anchored to this script's location so
+# the docs scan works no matter what the current working directory is.
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(_SCRIPT_DIR)
+DOCS_DIR = os.path.join(REPO_ROOT, "docs")
+EVALUATE_PY = os.path.join(_SCRIPT_DIR, "doc_agent", "evaluate.py")
 
 # Network behaviour.
 REQUEST_TIMEOUT = 30  # seconds
@@ -311,6 +325,41 @@ def write_freshness_report(results: list[dict], now: datetime) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Documentation evaluation
+# --------------------------------------------------------------------------- #
+
+def run_docs_evaluation() -> dict | None:
+    """Run the docs evaluation module against this repo's `docs/` folder.
+
+    `evaluate.py` lives in the `scripts/doc_agent/` package directory, which
+    shares a base name with this file (`scripts/doc_agent.py`). To avoid that
+    import ambiguity entirely, we load it directly by file path rather than
+    via `import doc_agent.evaluate`.
+    """
+    if not os.path.isfile(EVALUATE_PY):
+        print(f"  ! Evaluation module not found: {EVALUATE_PY}",
+              file=sys.stderr)
+        return None
+    if not os.path.isdir(DOCS_DIR):
+        print(f"  ! docs/ directory not found: {DOCS_DIR}", file=sys.stderr)
+        return None
+
+    spec = importlib.util.spec_from_file_location("doc_agent_evaluate",
+                                                  EVALUATE_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    results = module.run_evaluation(DOCS_DIR, EVAL_REPORT)
+    print(f"  + Docs evaluation written: {EVAL_REPORT}")
+    print(
+        f"    broken links: {len(results['broken_links'])}  |  "
+        f"stale docs: {len(results['staleness'])}  |  "
+        f"TODO/FIXME/XXX: {len(results['todos'])}"
+    )
+    return results
+
+
+# --------------------------------------------------------------------------- #
 # Orchestration
 # --------------------------------------------------------------------------- #
 
@@ -328,6 +377,9 @@ def main() -> int:
     print("\nGenerating outputs ...")
     write_blog_posts(results, now)
     report = write_freshness_report(results, now)
+
+    print("\nEvaluating existing documentation ...")
+    run_docs_evaluation()
 
     print("\n" + "=" * 60)
     print(report)

--- a/scripts/doc_agent.py
+++ b/scripts/doc_agent.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+OpenKruise Document Agent
+=========================
+
+An intelligent documentation agent for the OpenKruise website.
+
+What it does
+------------
+1. Fetches the latest releases / changelogs for the OpenKruise sub-projects
+   directly from the public GitHub Releases API (no auth token required).
+2. Extracts the latest release tag, release date and changelog body.
+3. Evaluates documentation freshness (a release older than STALE_AFTER_DAYS
+   days is flagged as STALE).
+4. Auto-generates a Docusaurus-compatible blog post for each sub-project.
+5. Writes a consolidated freshness report.
+
+Dependencies: Python standard library + `requests`.
+
+Run:
+    python scripts/doc_agent.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+
+# Sub-projects we track. `key` is used for filenames/tags, `name` for display.
+SUB_PROJECTS = [
+    {"key": "kruise",             "name": "Kruise",             "repo": "openkruise/kruise"},
+    {"key": "rollouts",           "name": "Rollouts",           "repo": "openkruise/rollouts"},
+    {"key": "kruise-game",        "name": "Kruise-Game",        "repo": "openkruise/kruise-game"},
+    {"key": "kruise-rollout-api", "name": "Kruise-Rollout-API", "repo": "openkruise/kruise-rollout-api"},
+]
+
+GITHUB_API = "https://api.github.com/repos/{repo}/releases"
+
+# A release whose publish date is older than this many days is considered stale.
+STALE_AFTER_DAYS = 30
+
+# Output locations.
+OUTPUT_ROOT = "agent-output"
+BLOG_DIR = os.path.join(OUTPUT_ROOT, "blogs")
+FRESHNESS_REPORT = os.path.join(OUTPUT_ROOT, "freshness-report.md")
+
+# Network behaviour.
+REQUEST_TIMEOUT = 30  # seconds
+REQUEST_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "openkruise-doc-agent",
+}
+
+
+# --------------------------------------------------------------------------- #
+# GitHub fetching
+# --------------------------------------------------------------------------- #
+
+def fetch_latest_release(repo: str) -> dict | None:
+    """Fetch the most recent published, non-draft release for a repo.
+
+    Returns a normalized dict, or None if the repo has no usable release.
+    Network / API failures are caught and reported so a single bad repo
+    does not abort the whole run.
+    """
+    url = GITHUB_API.format(repo=repo)
+    try:
+        resp = requests.get(url, headers=REQUEST_HEADERS, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        releases = resp.json()
+    except requests.RequestException as exc:
+        print(f"  ! Failed to fetch releases for {repo}: {exc}", file=sys.stderr)
+        return None
+    except json.JSONDecodeError as exc:
+        print(f"  ! Invalid JSON from GitHub for {repo}: {exc}", file=sys.stderr)
+        return None
+
+    if not isinstance(releases, list) or not releases:
+        print(f"  ! No releases found for {repo}", file=sys.stderr)
+        return None
+
+    # Skip drafts; published_at is null for drafts anyway. Pick the newest by
+    # published_at so we are not relying solely on API ordering.
+    published = [r for r in releases if not r.get("draft") and r.get("published_at")]
+    if not published:
+        print(f"  ! No published releases for {repo}", file=sys.stderr)
+        return None
+
+    latest = max(published, key=lambda r: r["published_at"])
+
+    return {
+        "tag": latest.get("tag_name", "unknown"),
+        "name": latest.get("name") or latest.get("tag_name", "unknown"),
+        "published_at": latest["published_at"],
+        "body": latest.get("body") or "",
+        "html_url": latest.get("html_url", f"https://github.com/{repo}/releases"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Freshness evaluation
+# --------------------------------------------------------------------------- #
+
+def parse_iso8601(value: str) -> datetime:
+    """Parse a GitHub ISO-8601 timestamp (e.g. 2024-01-01T12:00:00Z)."""
+    # Python's fromisoformat handles the trailing 'Z' from 3.11+, but we
+    # normalize it explicitly for safety on older interpreters.
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def evaluate_freshness(published_at: str, now: datetime) -> tuple[int, str]:
+    """Return (days_since_release, status) where status is FRESH or STALE."""
+    released = parse_iso8601(published_at)
+    days_since = (now - released).days
+    status = "STALE" if days_since > STALE_AFTER_DAYS else "FRESH"
+    return days_since, status
+
+
+# --------------------------------------------------------------------------- #
+# Changelog parsing
+# --------------------------------------------------------------------------- #
+
+def extract_highlights(body: str, limit: int = 5) -> list[str]:
+    """Extract the top `limit` bullet points from a release body.
+
+    Release notes vary a lot in format, so we look for markdown list items
+    (`-`, `*`, `+`) and clean them up: strip markdown links to plain text,
+    drop bold/inline-code markers, and skip empty or noise lines.
+    """
+    highlights: list[str] = []
+
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        match = re.match(r"^[-*+]\s+(.*)", line)
+        if not match:
+            continue
+
+        text = match.group(1).strip()
+
+        # Convert markdown links [text](url) -> text
+        text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+        # Drop bold/italic/inline-code markers.
+        text = re.sub(r"[`*_]+", "", text)
+        # Collapse internal whitespace.
+        text = re.sub(r"\s+", " ", text).strip()
+
+        # Skip empties and pure-noise lines (e.g. "..." or bare links).
+        if not text or len(text) < 3:
+            continue
+
+        highlights.append(text)
+        if len(highlights) >= limit:
+            break
+
+    return highlights
+
+
+def extract_prose_summary(body: str, max_sentences: int = 3) -> str:
+    """Fallback when a release body has no bullet points.
+
+    Some releases (e.g. point releases that just link to a CHANGELOG) carry
+    only prose. We take the first meaningful paragraph, drop markdown
+    headings / changelog footers / bare links, flatten links to plain text,
+    and keep at most `max_sentences` sentences.
+    """
+    paragraph: list[str] = []
+
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+
+        # Skip blanks once we've started collecting -> end of first paragraph.
+        if not line:
+            if paragraph:
+                break
+            continue
+        # Skip markdown headings and the GitHub auto-generated changelog footer.
+        if line.startswith("#") or line.lower().startswith("**full changelog"):
+            continue
+
+        paragraph.append(line)
+
+    text = " ".join(paragraph)
+    # Flatten markdown links [text](url) -> text, then strip emphasis markers.
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"[`*_]+", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+
+    if not text:
+        return ""
+
+    # Keep at most `max_sentences` sentences.
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    return " ".join(sentences[:max_sentences]).strip()
+
+
+# --------------------------------------------------------------------------- #
+# Output generation
+# --------------------------------------------------------------------------- #
+
+def generate_blog_post(project: dict, release: dict, now: datetime) -> str:
+    """Build a Docusaurus-compatible blog post for one sub-project release."""
+    release_date = parse_iso8601(release["published_at"]).date().isoformat()
+    version = release["tag"]
+    title = f'OpenKruise {project["name"]} {version} Released'
+
+    highlights = extract_highlights(release["body"], limit=5)
+    if highlights:
+        highlights_md = "\n".join(f"- {h}" for h in highlights)
+    else:
+        # No bullet points in the release body — fall back to a prose summary.
+        prose = extract_prose_summary(release["body"])
+        highlights_md = prose or "_See the linked release notes for full details._"
+
+    # Built line-by-line (not via textwrap.dedent) because dedent fails to
+    # find a common indent once multi-line highlights inject a zero-indent
+    # line, which would leave the YAML front matter indented and unparseable.
+    return "\n".join(
+        [
+            "---",
+            f'title: "{title}"',
+            f"date: {release_date}",
+            "author: OpenKruise Community",
+            f'tags: [{project["key"]}, release]',
+            "---",
+            "",
+            f"## What's New in {version}",
+            "",
+            highlights_md,
+            "",
+            f'For the full changelog, see the [release notes]({release["html_url"]}).',
+            "",
+        ]
+    )
+
+
+def write_blog_posts(results: list[dict], now: datetime) -> list[str]:
+    """Write one blog post per sub-project. Returns list of written paths."""
+    os.makedirs(BLOG_DIR, exist_ok=True)
+    written = []
+
+    for item in results:
+        if not item["release"]:
+            continue
+        project, release = item["project"], item["release"]
+        release_date = parse_iso8601(release["published_at"]).date().isoformat()
+
+        # Docusaurus blog convention: YYYY-MM-DD-slug.md
+        filename = f'{release_date}-{project["key"]}-{release["tag"]}.md'
+        path = os.path.join(BLOG_DIR, filename)
+
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(generate_blog_post(project, release, now))
+
+        written.append(path)
+        print(f"  + Blog post written: {path}")
+
+    return written
+
+
+def write_freshness_report(results: list[dict], now: datetime) -> str:
+    """Write the consolidated freshness report markdown table."""
+    os.makedirs(OUTPUT_ROOT, exist_ok=True)
+
+    lines = [
+        "# OpenKruise Documentation Freshness Report",
+        "",
+        f"_Generated on {now.strftime('%Y-%m-%d %H:%M UTC')} "
+        f"by the OpenKruise Document Agent._",
+        "",
+        f"A release is flagged **STALE** when its publish date is more than "
+        f"{STALE_AFTER_DAYS} days old.",
+        "",
+        "| Sub-Project | Latest Version | Release Date | Days Since Release | Status |",
+        "| ----------- | -------------- | ------------ | ------------------ | ------ |",
+    ]
+
+    for item in results:
+        project = item["project"]
+        release = item["release"]
+        if not release:
+            lines.append(
+                f'| {project["name"]} | _n/a_ | _n/a_ | _n/a_ | ⚠️ UNKNOWN |'
+            )
+            continue
+
+        days_since, status = evaluate_freshness(release["published_at"], now)
+        release_date = parse_iso8601(release["published_at"]).date().isoformat()
+        badge = "🟢 FRESH" if status == "FRESH" else "🔴 STALE"
+        lines.append(
+            f'| {project["name"]} | {release["tag"]} | {release_date} '
+            f"| {days_since} | {badge} |"
+        )
+
+    lines.append("")
+    content = "\n".join(lines)
+
+    with open(FRESHNESS_REPORT, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+    print(f"  + Freshness report written: {FRESHNESS_REPORT}")
+    return content
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    print(f"OpenKruise Document Agent — run at {now.isoformat()}\n")
+
+    results = []
+    print("Fetching releases from GitHub ...")
+    for project in SUB_PROJECTS:
+        print(f"  - {project['repo']}")
+        release = fetch_latest_release(project["repo"])
+        results.append({"project": project, "release": release})
+
+    print("\nGenerating outputs ...")
+    write_blog_posts(results, now)
+    report = write_freshness_report(results, now)
+
+    print("\n" + "=" * 60)
+    print(report)
+
+    # Exit non-zero if any sub-project could not be fetched, so CI surfaces it.
+    failed = [r["project"]["name"] for r in results if not r["release"]]
+    if failed:
+        print(f"\nWARNING: could not fetch releases for: {', '.join(failed)}",
+              file=sys.stderr)
+        return 1
+
+    print("\nDone. All sub-projects processed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doc_agent.py
+++ b/scripts/doc_agent.py
@@ -14,8 +14,10 @@ What it does
    days is flagged as STALE).
 4. Auto-generates a Docusaurus-compatible blog post for each sub-project.
 5. Writes a consolidated freshness report.
-6. Evaluates the existing `docs/` folder (broken links, stale pages,
-   TODO/FIXME markers) and writes a documentation evaluation report.
+6. Evaluates the existing `docs/` folder (broken internal links, broken
+   external links, stale pages, TODO/FIXME/XXX markers) and writes a
+   documentation evaluation report. External link checking honours the
+   `SKIP_EXTERNAL_LINKS` env var for offline / CI runs.
 
 Full pipeline: fetch releases -> generate blogs -> evaluate docs ->
 write all reports.
@@ -350,9 +352,12 @@ def run_docs_evaluation() -> dict | None:
     spec.loader.exec_module(module)
 
     results = module.run_evaluation(DOCS_DIR, EVAL_REPORT)
+    ext = ("skipped" if results.get("external_skipped")
+           else len(results["external_links"]))
     print(f"  + Docs evaluation written: {EVAL_REPORT}")
     print(
-        f"    broken links: {len(results['broken_links'])}  |  "
+        f"    broken internal links: {len(results['broken_links'])}  |  "
+        f"broken external links: {ext}  |  "
         f"stale docs: {len(results['staleness'])}  |  "
         f"TODO/FIXME/XXX: {len(results['todos'])}"
     )

--- a/scripts/doc_agent/checkers/__init__.py
+++ b/scripts/doc_agent/checkers/__init__.py
@@ -1,0 +1,9 @@
+"""Documentation evaluation checkers for the OpenKruise Document Agent.
+
+Each checker module exposes a single entry point::
+
+    def run(docs_dir: str) -> list[dict]
+
+so the evaluator can call them uniformly. Checkers are intentionally
+independent (no shared state) so they can be run or tested in isolation.
+"""

--- a/scripts/doc_agent/checkers/broken_links.py
+++ b/scripts/doc_agent/checkers/broken_links.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Broken-link checker.
+
+Scans every Markdown file under ``docs_dir`` and reports inline links that
+are either:
+
+* **empty_link**   — ``[text]()`` (no destination at all)
+* **missing_file** — ``[text](./relative/path.md)`` pointing at a local file
+  that does not exist on disk
+
+External links (http/https/mailto/...), protocol-relative links, pure
+anchors (``#section``) and site-absolute Docusaurus routes (``/foo/bar``)
+are intentionally skipped: they cannot be validated from the filesystem
+alone, and flagging them would produce false positives.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+# Capture an optional leading "!" (so we can skip images), the link text,
+# and the destination. Whitespace around the destination is tolerated.
+_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\(\s*([^)]*?)\s*\)")
+
+# Destinations we never try to resolve on disk.
+_EXTERNAL_SCHEMES = ("http://", "https://", "ftp://", "mailto:", "tel:")
+
+
+def _iter_md_files(docs_dir: str):
+    """Yield absolute paths of every ``.md`` file under ``docs_dir``."""
+    for root, _dirs, files in os.walk(docs_dir):
+        for name in sorted(files):
+            if name.endswith(".md"):
+                yield os.path.join(root, name)
+
+
+def _is_external(dest: str) -> bool:
+    """True for links we should not resolve against the filesystem."""
+    lowered = dest.lower()
+    if lowered.startswith(_EXTERNAL_SCHEMES):
+        return True
+    if dest.startswith("//"):  # protocol-relative
+        return True
+    if dest.startswith("#"):  # pure in-page anchor
+        return True
+    # Site-absolute Docusaurus route (e.g. "/kruise/installation"): not a
+    # filesystem path, so resolving it here is unreliable -> skip.
+    if dest.startswith("/"):
+        return True
+    return False
+
+
+def _resolves(dest: str, source_file: str) -> bool:
+    """Return True if a local destination maps to a file that exists.
+
+    Handles the common Docusaurus shapes: an explicit ``.md``/``.mdx`` file,
+    an extensionless path, or a directory with an ``index``/``README``.
+    """
+    # Strip anchor / query fragments before touching the filesystem.
+    path = re.split(r"[#?]", dest, maxsplit=1)[0].strip()
+    if not path:  # destination was only an anchor/query
+        return True
+
+    base_dir = os.path.dirname(source_file)
+    target = os.path.normpath(os.path.join(base_dir, path))
+
+    candidates = [
+        target,
+        target + ".md",
+        target + ".mdx",
+        os.path.join(target, "index.md"),
+        os.path.join(target, "index.mdx"),
+        os.path.join(target, "README.md"),
+    ]
+    return any(os.path.isfile(c) for c in candidates)
+
+
+def run(docs_dir: str) -> list[dict]:
+    """Scan ``docs_dir`` and return a list of broken-link findings."""
+    findings: list[dict] = []
+
+    for md_file in _iter_md_files(docs_dir):
+        try:
+            with open(md_file, encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except OSError:
+            continue
+
+        for lineno, line in enumerate(lines, start=1):
+            for match in _LINK_RE.finditer(line):
+                is_image, text, dest = match.group(1), match.group(2), match.group(3)
+                if is_image:  # ![alt](src) is an image, not a link
+                    continue
+
+                if dest == "" or dest.strip() == "":
+                    findings.append({
+                        "file": md_file,
+                        "line": lineno,
+                        "link_text": text.strip(),
+                        "issue_type": "empty_link",
+                    })
+                    continue
+
+                if _is_external(dest):
+                    continue
+
+                if not _resolves(dest, md_file):
+                    findings.append({
+                        "file": md_file,
+                        "line": lineno,
+                        "link_text": text.strip(),
+                        "issue_type": "missing_file",
+                    })
+
+    return findings
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    target = sys.argv[1] if len(sys.argv) > 1 else "docs"
+    print(json.dumps(run(target), indent=2))

--- a/scripts/doc_agent/checkers/external_links.py
+++ b/scripts/doc_agent/checkers/external_links.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""External-link checker.
+
+Scans every Markdown file under ``docs_dir`` for external ``http(s)`` links
+(the ``[text](https://...)`` form) and verifies each one is reachable.
+
+Behaviour
+---------
+* **HEAD request**, 10 second timeout, redirects followed — a link that
+  301/302s to a healthy page is considered fine.
+* A link is reported when the final response is **not 2xx**, or the request
+  **times out / fails to connect**.
+* If the server answers a HEAD with **405 Method Not Allowed**, the URL is
+  retried once with a lightweight streaming GET. Many CDNs disallow HEAD but
+  serve GET correctly; reporting them would be a false positive.
+* Requests are **rate-limited to one per second** to stay polite to hosts.
+* Each unique URL is checked **once**, even if it appears in many files, so
+  the report stays small and no host is hammered.
+* Set the ``SKIP_EXTERNAL_LINKS`` environment variable to skip the check
+  entirely (offline / CI mode). ``run()`` then returns an empty list.
+
+Returns a list of ``{file, line, url, status}`` dicts (``file``/``line`` is
+the first place each broken URL was seen).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+
+import requests
+
+# Markdown inline link whose destination is an absolute http(s) URL.
+_URL_RE = re.compile(r"\[[^\]]*\]\(\s*(https?://[^)\s]+?)\s*\)")
+
+_TIMEOUT = 10  # seconds, per the requirements
+_RATE_LIMIT_SECONDS = 1.0  # at most one request per second
+_HEADERS = {"User-Agent": "openkruise-doc-agent-linkcheck"}
+
+SKIP_ENV_VAR = "SKIP_EXTERNAL_LINKS"
+
+
+def _iter_md_files(docs_dir: str):
+    """Yield absolute paths of every ``.md`` file under ``docs_dir``."""
+    for root, _dirs, files in os.walk(docs_dir):
+        for name in sorted(files):
+            if name.endswith(".md"):
+                yield os.path.join(root, name)
+
+
+def _collect_links(docs_dir: str) -> dict[str, tuple[str, int]]:
+    """Map each unique external URL to the first (file, line) it appears at."""
+    seen: dict[str, tuple[str, int]] = {}
+    for md_file in _iter_md_files(docs_dir):
+        try:
+            with open(md_file, encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except OSError:
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            for match in _URL_RE.finditer(line):
+                url = match.group(1)
+                seen.setdefault(url, (md_file, lineno))
+    return seen
+
+
+def _check(url: str) -> tuple[bool, str]:
+    """Return (ok, status) for a single URL."""
+    try:
+        resp = requests.head(
+            url, allow_redirects=True, timeout=_TIMEOUT, headers=_HEADERS
+        )
+        # Some servers reject HEAD outright — retry once with GET.
+        if resp.status_code in (403, 405):
+            resp = requests.get(
+                url, allow_redirects=True, timeout=_TIMEOUT,
+                headers=_HEADERS, stream=True,
+            )
+            resp.close()
+        ok = 200 <= resp.status_code < 300
+        return ok, str(resp.status_code)
+    except requests.Timeout:
+        return False, "timeout"
+    except requests.RequestException as exc:
+        return False, f"error: {type(exc).__name__}"
+
+
+def run(docs_dir: str) -> list[dict]:
+    """Scan ``docs_dir`` and return unreachable external links.
+
+    Honours ``SKIP_EXTERNAL_LINKS``: when set, returns ``[]`` without making
+    any network request.
+    """
+    if os.environ.get(SKIP_ENV_VAR):
+        return []
+
+    links = _collect_links(docs_dir)
+    findings: list[dict] = []
+
+    for index, (url, (md_file, lineno)) in enumerate(sorted(links.items())):
+        if index > 0:  # rate-limit: one request per second (none before the first)
+            time.sleep(_RATE_LIMIT_SECONDS)
+
+        ok, status = _check(url)
+        if not ok:
+            findings.append({
+                "file": md_file,
+                "line": lineno,
+                "url": url,
+                "status": status,
+            })
+
+    return findings
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    target = sys.argv[1] if len(sys.argv) > 1 else "docs"
+    print(json.dumps(run(target), indent=2))

--- a/scripts/doc_agent/checkers/staleness.py
+++ b/scripts/doc_agent/checkers/staleness.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Staleness checker.
+
+Scans every Markdown file under ``docs_dir`` and reports any file whose
+*last git commit* is older than ``STALE_AFTER_DAYS`` days. The last-modified
+date is taken from git history (committer date) rather than the filesystem
+mtime, because a fresh checkout rewrites mtimes and would hide real staleness.
+
+Files with no git history (newly added, not yet committed) are skipped:
+they are new, not stale.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import datetime, timezone
+
+STALE_AFTER_DAYS = 180
+
+
+def _iter_md_files(docs_dir: str):
+    """Yield absolute paths of every ``.md`` file under ``docs_dir``."""
+    for root, _dirs, files in os.walk(docs_dir):
+        for name in sorted(files):
+            if name.endswith(".md"):
+                yield os.path.join(root, name)
+
+
+def _git_repo_root(path: str) -> str | None:
+    """Return the git top-level directory containing ``path``, or None."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _last_commit_iso(repo_root: str, file_path: str) -> str | None:
+    """Return the ISO-8601 committer date of the last commit touching a file."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_root, "log", "-1", "--format=%cI", "--", file_path],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    stamp = out.stdout.strip()
+    return stamp or None
+
+
+def run(docs_dir: str) -> list[dict]:
+    """Scan ``docs_dir`` and return files whose last commit is too old."""
+    repo_root = _git_repo_root(docs_dir)
+    if repo_root is None:
+        # Not a git repository (or git unavailable) — nothing we can assess.
+        return []
+
+    now = datetime.now(timezone.utc)
+    findings: list[dict] = []
+
+    for md_file in _iter_md_files(docs_dir):
+        stamp = _last_commit_iso(repo_root, md_file)
+        if not stamp:  # no commit history -> newly added, not stale
+            continue
+
+        committed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+        days_since = (now - committed).days
+        if days_since > STALE_AFTER_DAYS:
+            findings.append({
+                "file": md_file,
+                "last_modified": committed.date().isoformat(),
+                "days_since": days_since,
+            })
+
+    return findings
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    target = sys.argv[1] if len(sys.argv) > 1 else "docs"
+    print(json.dumps(run(target), indent=2))

--- a/scripts/doc_agent/checkers/todo_scan.py
+++ b/scripts/doc_agent/checkers/todo_scan.py
@@ -2,9 +2,14 @@
 """TODO / FIXME / XXX scanner.
 
 Scans every Markdown file under ``docs_dir`` for unfinished-work markers.
-Matching is case-sensitive on the conventional upper-case spellings
-(``TODO``, ``FIXME``, ``XXX``) with word boundaries, so ordinary prose such
-as "to do this" or "fix me" does not generate noise.
+Matching uses word boundaries and a deliberately *hybrid* casing policy:
+
+* ``TODO`` / ``FIXME`` — **case-insensitive** (``todo``, ``Fixme``, ... all
+  count). These spellings rarely occur by accident in prose.
+* ``XXX`` — **upper-case only**. Lower-case ``xxx`` is far too common in
+  placeholders, redactions and URLs to treat as a marker.
+
+Reported markers are normalised to their canonical upper-case form.
 
 Two sources of false positives are deliberately excluded:
 
@@ -20,7 +25,9 @@ from __future__ import annotations
 import os
 import re
 
-_MARKER_RE = re.compile(r"\b(TODO|FIXME|XXX)\b")
+# `(?i:TODO|FIXME)` is case-insensitive only inside that scoped group;
+# `XXX` outside it stays case-sensitive (upper-case only).
+_MARKER_RE = re.compile(r"\b((?i:TODO|FIXME)|XXX)\b")
 
 # A line that opens or closes a fenced code block.
 _FENCE_RE = re.compile(r"^\s*(```|~~~)")
@@ -68,7 +75,7 @@ def run(docs_dir: str) -> list[dict]:
                 findings.append({
                     "file": md_file,
                     "line": lineno,
-                    "marker": match.group(1),
+                    "marker": match.group(1).upper(),  # normalise todo -> TODO
                     "context": context,
                 })
 

--- a/scripts/doc_agent/checkers/todo_scan.py
+++ b/scripts/doc_agent/checkers/todo_scan.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""TODO / FIXME / XXX scanner.
+
+Scans every Markdown file under ``docs_dir`` for unfinished-work markers.
+Matching is case-sensitive on the conventional upper-case spellings
+(``TODO``, ``FIXME``, ``XXX``) with word boundaries, so ordinary prose such
+as "to do this" or "fix me" does not generate noise.
+
+Two sources of false positives are deliberately excluded:
+
+* **Fenced code blocks** (```` ``` ````/``~~~``). Markers inside example
+  code are part of the sample, not documentation work items — e.g. the Go
+  client docs are full of legitimate ``context.TODO()`` calls.
+* **Function-call forms** like ``TODO(`` — these are API calls
+  (``context.TODO()``), not annotations.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+_MARKER_RE = re.compile(r"\b(TODO|FIXME|XXX)\b")
+
+# A line that opens or closes a fenced code block.
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+# Keep report rows readable.
+_CONTEXT_MAX = 120
+
+
+def _iter_md_files(docs_dir: str):
+    """Yield absolute paths of every ``.md`` file under ``docs_dir``."""
+    for root, _dirs, files in os.walk(docs_dir):
+        for name in sorted(files):
+            if name.endswith(".md"):
+                yield os.path.join(root, name)
+
+
+def run(docs_dir: str) -> list[dict]:
+    """Scan ``docs_dir`` and return every TODO/FIXME/XXX occurrence."""
+    findings: list[dict] = []
+
+    for md_file in _iter_md_files(docs_dir):
+        try:
+            with open(md_file, encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except OSError:
+            continue
+
+        in_code_fence = False
+        for lineno, line in enumerate(lines, start=1):
+            if _FENCE_RE.match(line):
+                in_code_fence = not in_code_fence
+                continue
+            if in_code_fence:
+                continue
+
+            context = line.strip()
+            if len(context) > _CONTEXT_MAX:
+                context = context[:_CONTEXT_MAX].rstrip() + "…"
+
+            for match in _MARKER_RE.finditer(line):
+                # Skip API-call forms like `context.TODO()` — not annotations.
+                if line[match.end():match.end() + 1] == "(":
+                    continue
+
+                findings.append({
+                    "file": md_file,
+                    "line": lineno,
+                    "marker": match.group(1),
+                    "context": context,
+                })
+
+    return findings
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    target = sys.argv[1] if len(sys.argv) > 1 else "docs"
+    print(json.dumps(run(target), indent=2))

--- a/scripts/doc_agent/evaluate.py
+++ b/scripts/doc_agent/evaluate.py
@@ -27,7 +27,12 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 
-from checkers import broken_links, staleness, todo_scan  # noqa: E402
+from checkers import (  # noqa: E402
+    broken_links,
+    external_links,
+    staleness,
+    todo_scan,
+)
 
 # Repo root = .../scripts/doc_agent/evaluate.py -> up three levels.
 _REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
@@ -70,8 +75,12 @@ def _build_report(docs_dir: str, results: dict, now: datetime) -> str:
     n_files = _count_md_files(docs_dir)
 
     links = results["broken_links"]
+    external = results["external_links"]
+    ext_skipped = results.get("external_skipped", False)
     stale = results["staleness"]
     todos = results["todos"]
+
+    ext_summary = "⏭️ skipped" if ext_skipped else str(len(external))
 
     lines: list[str] = [
         "# OpenKruise Documentation Evaluation Report",
@@ -88,14 +97,15 @@ def _build_report(docs_dir: str, results: dict, now: datetime) -> str:
     lines += _table(
         ["Check", "Issues"],
         [
-            ["🔗 Broken links", str(len(links))],
+            ["🔗 Broken internal links", str(len(links))],
+            ["🌐 Broken external links", ext_summary],
             ["🕒 Stale docs (> 180 days)", str(len(stale))],
             ["📝 TODO / FIXME / XXX", str(len(todos))],
         ],
     )
 
-    # --- Broken links ----------------------------------------------------- #
-    lines += ["", f"## 🔗 Broken Links ({len(links)})", ""]
+    # --- Broken internal links ------------------------------------------- #
+    lines += ["", f"## 🔗 Broken Internal Links ({len(links)})", ""]
     if links:
         lines += _table(
             ["File", "Line", "Link Text", "Issue"],
@@ -106,7 +116,29 @@ def _build_report(docs_dir: str, results: dict, now: datetime) -> str:
             ],
         )
     else:
-        lines.append("✅ No broken links found.")
+        lines.append("✅ No broken internal links found.")
+
+    # --- Broken external links ------------------------------------------- #
+    if ext_skipped:
+        lines += [
+            "", "## 🌐 Broken External Links (skipped)", "",
+            f"⏭️ Skipped — `{external_links.SKIP_ENV_VAR}` is set "
+            "(offline / CI mode).",
+        ]
+    else:
+        lines += ["", f"## 🌐 Broken External Links ({len(external)})", "",
+                  "_HEAD request, 10s timeout, redirects followed, "
+                  "rate-limited to 1 req/s._", ""]
+        if external:
+            lines += _table(
+                ["File", "Line", "URL", "Status"],
+                [
+                    [_rel(i["file"], base), i["line"], i["url"], i["status"]]
+                    for i in external
+                ],
+            )
+        else:
+            lines.append("✅ No broken external links found.")
 
     # --- Stale docs ------------------------------------------------------- #
     lines += ["", f"## 🕒 Stale Documentation ({len(stale)})", "",
@@ -144,10 +176,14 @@ def run_evaluation(docs_dir: str, output_path: str) -> dict:
     """Run all checkers, write the report, and return the aggregated results."""
     now = datetime.now(timezone.utc)
 
+    external_skipped = bool(os.environ.get(external_links.SKIP_ENV_VAR))
+
     results = {
         "broken_links": broken_links.run(docs_dir),
+        "external_links": external_links.run(docs_dir),
         "staleness": staleness.run(docs_dir),
         "todos": todo_scan.run(docs_dir),
+        "external_skipped": external_skipped,
     }
 
     report = _build_report(docs_dir, results, now)

--- a/scripts/doc_agent/evaluate.py
+++ b/scripts/doc_agent/evaluate.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Documentation evaluation aggregator.
+
+Runs every checker in ``scripts/doc_agent/checkers/`` against a docs folder
+and writes a single consolidated Markdown report.
+
+Can be used two ways:
+
+* **Standalone** ::
+
+      python scripts/doc_agent/evaluate.py [docs_dir] [output_path]
+
+* **Imported** by ``scripts/doc_agent.py`` as the final agent step::
+
+      run_evaluation(docs_dir, output_path) -> dict
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+# Make the sibling ``checkers`` package importable regardless of the current
+# working directory or how this file is loaded (CLI or importlib-by-path).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from checkers import broken_links, staleness, todo_scan  # noqa: E402
+
+# Repo root = .../scripts/doc_agent/evaluate.py -> up three levels.
+_REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
+
+DEFAULT_DOCS_DIR = os.path.join(_REPO_ROOT, "docs")
+DEFAULT_OUTPUT = os.path.join(
+    _REPO_ROOT, "agent-output", "docs-evaluation-report.md"
+)
+
+
+def _count_md_files(docs_dir: str) -> int:
+    total = 0
+    for _root, _dirs, files in os.walk(docs_dir):
+        total += sum(1 for n in files if n.endswith(".md"))
+    return total
+
+
+def _rel(path: str, base: str) -> str:
+    """Display path relative to ``base`` (falls back to the raw path)."""
+    try:
+        return os.path.relpath(path, base)
+    except ValueError:
+        return path
+
+
+def _cell(text: str) -> str:
+    """Escape a value so it is safe inside a Markdown table cell."""
+    return str(text).replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    out = ["| " + " | ".join(headers) + " |",
+           "| " + " | ".join("---" for _ in headers) + " |"]
+    out += ["| " + " | ".join(_cell(c) for c in row) + " |" for row in rows]
+    return out
+
+
+def _build_report(docs_dir: str, results: dict, now: datetime) -> str:
+    base = os.path.dirname(os.path.abspath(docs_dir.rstrip("/")))
+    n_files = _count_md_files(docs_dir)
+
+    links = results["broken_links"]
+    stale = results["staleness"]
+    todos = results["todos"]
+
+    lines: list[str] = [
+        "# OpenKruise Documentation Evaluation Report",
+        "",
+        f"_Generated on {now.strftime('%Y-%m-%d %H:%M UTC')} "
+        f"by the OpenKruise Document Agent._",
+        "",
+        f"**Scanned:** `{_rel(docs_dir, _REPO_ROOT)}/` — "
+        f"{n_files} Markdown files",
+        "",
+        "## Summary",
+        "",
+    ]
+    lines += _table(
+        ["Check", "Issues"],
+        [
+            ["🔗 Broken links", str(len(links))],
+            ["🕒 Stale docs (> 180 days)", str(len(stale))],
+            ["📝 TODO / FIXME / XXX", str(len(todos))],
+        ],
+    )
+
+    # --- Broken links ----------------------------------------------------- #
+    lines += ["", f"## 🔗 Broken Links ({len(links)})", ""]
+    if links:
+        lines += _table(
+            ["File", "Line", "Link Text", "Issue"],
+            [
+                [_rel(i["file"], base), i["line"],
+                 i["link_text"] or "_(empty)_", i["issue_type"]]
+                for i in links
+            ],
+        )
+    else:
+        lines.append("✅ No broken links found.")
+
+    # --- Stale docs ------------------------------------------------------- #
+    lines += ["", f"## 🕒 Stale Documentation ({len(stale)})", "",
+              "_Files whose last git commit is more than "
+              f"{staleness.STALE_AFTER_DAYS} days old._", ""]
+    if stale:
+        lines += _table(
+            ["File", "Last Modified", "Days Since"],
+            [
+                [_rel(i["file"], base), i["last_modified"], i["days_since"]]
+                for i in sorted(stale, key=lambda x: -x["days_since"])
+            ],
+        )
+    else:
+        lines.append("✅ No stale documentation found.")
+
+    # --- TODO / FIXME / XXX ---------------------------------------------- #
+    lines += ["", f"## 📝 TODO / FIXME / XXX Markers ({len(todos)})", ""]
+    if todos:
+        lines += _table(
+            ["File", "Line", "Marker", "Context"],
+            [
+                [_rel(i["file"], base), i["line"], i["marker"], i["context"]]
+                for i in todos
+            ],
+        )
+    else:
+        lines.append("✅ No TODO/FIXME/XXX markers found.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run_evaluation(docs_dir: str, output_path: str) -> dict:
+    """Run all checkers, write the report, and return the aggregated results."""
+    now = datetime.now(timezone.utc)
+
+    results = {
+        "broken_links": broken_links.run(docs_dir),
+        "staleness": staleness.run(docs_dir),
+        "todos": todo_scan.run(docs_dir),
+    }
+
+    report = _build_report(docs_dir, results, now)
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as fh:
+        fh.write(report)
+
+    results["report"] = report
+    results["output_path"] = output_path
+    return results
+
+
+def main() -> int:
+    docs_dir = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DOCS_DIR
+    output_path = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_OUTPUT
+
+    if not os.path.isdir(docs_dir):
+        print(f"ERROR: docs directory not found: {docs_dir}", file=sys.stderr)
+        return 1
+
+    results = run_evaluation(docs_dir, output_path)
+    print(f"Evaluation report written: {output_path}")
+    print(
+        f"  broken links: {len(results['broken_links'])}  |  "
+        f"stale docs: {len(results['staleness'])}  |  "
+        f"TODO/FIXME/XXX: {len(results['todos'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest setup.
+
+The checkers live in ``scripts/doc_agent/checkers/``. Putting that package's
+parent (``scripts/doc_agent``) on ``sys.path`` lets the tests do a clean
+``from checkers import ...`` — the same mechanism ``evaluate.py`` uses, so
+the tests exercise the modules exactly as the agent loads them.
+"""
+
+import os
+import sys
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_CHECKERS_PARENT = os.path.join(
+    os.path.dirname(_TESTS_DIR), "scripts", "doc_agent"
+)
+
+if _CHECKERS_PARENT not in sys.path:
+    sys.path.insert(0, _CHECKERS_PARENT)

--- a/tests/test_broken_links.py
+++ b/tests/test_broken_links.py
@@ -1,0 +1,76 @@
+"""Tests for the internal broken-link checker.
+
+All tests are filesystem-only (no network), so the suite stays fast.
+"""
+
+from checkers import broken_links
+
+
+def _md(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_empty_href_is_flagged(tmp_path):
+    _md(tmp_path, "a.md", "Please read the [docs]() carefully.\n")
+
+    result = broken_links.run(str(tmp_path))
+
+    assert len(result) == 1
+    assert result[0]["issue_type"] == "empty_link"
+    assert result[0]["link_text"] == "docs"
+    assert result[0]["line"] == 1
+
+
+def test_missing_local_file_is_flagged(tmp_path):
+    _md(tmp_path, "a.md", "See [the guide](./missing.md) for details.\n")
+
+    result = broken_links.run(str(tmp_path))
+
+    assert [r["issue_type"] for r in result] == ["missing_file"]
+    assert result[0]["link_text"] == "the guide"
+
+
+def test_existing_local_file_is_ok(tmp_path):
+    _md(tmp_path, "target.md", "# Target\n")
+    _md(tmp_path, "a.md", "Link to [target](./target.md).\n")
+
+    assert broken_links.run(str(tmp_path)) == []
+
+
+def test_extensionless_link_resolves_to_md(tmp_path):
+    # Docusaurus-style link without the .md suffix should still resolve.
+    _md(tmp_path, "target.md", "# Target\n")
+    _md(tmp_path, "a.md", "Link to [target](./target).\n")
+
+    assert broken_links.run(str(tmp_path)) == []
+
+
+def test_external_anchor_and_site_absolute_are_skipped(tmp_path):
+    _md(
+        tmp_path,
+        "a.md",
+        "[ext](https://example.com) "
+        "[anchor](#section) "
+        "[mail](mailto:dev@example.com) "
+        "[abs](/kruise/installation)\n",
+    )
+
+    # None of these can be validated from the filesystem -> no findings.
+    assert broken_links.run(str(tmp_path)) == []
+
+
+def test_images_are_not_treated_as_links(tmp_path):
+    # `![alt](src)` is an image, not a link, even if the target is missing.
+    _md(tmp_path, "a.md", "![diagram](./missing.png)\n")
+
+    assert broken_links.run(str(tmp_path)) == []
+
+
+def test_line_numbers_are_reported(tmp_path):
+    _md(tmp_path, "a.md", "line one\n\n[bad](./nope.md)\n")
+
+    result = broken_links.run(str(tmp_path))
+
+    assert result[0]["line"] == 3

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -1,0 +1,89 @@
+"""Tests for the staleness checker.
+
+Git is never actually invoked: ``subprocess.run`` is mocked so the tests are
+deterministic and fast, and so they work even outside a git checkout.
+"""
+
+import types
+from datetime import datetime, timedelta, timezone
+from subprocess import CalledProcessError
+from unittest import mock
+
+from checkers import staleness
+
+
+def _completed(stdout):
+    """Stand-in for the subprocess.CompletedProcess the real calls return."""
+    return types.SimpleNamespace(stdout=stdout, stderr="", returncode=0)
+
+
+def _iso(days_ago):
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.isoformat()
+
+
+def _git_mock(repo_root, dates_by_suffix):
+    """Build a subprocess.run side-effect.
+
+    ``git rev-parse`` -> repo root; ``git log`` -> the ISO date chosen by
+    matching the trailing file path against ``dates_by_suffix``.
+    """
+    def fake_run(cmd, *args, **kwargs):
+        if "rev-parse" in cmd:
+            return _completed(repo_root + "\n")
+        target = cmd[-1]  # the file path after "--"
+        for suffix, iso in dates_by_suffix.items():
+            if target.endswith(suffix):
+                return _completed((iso + "\n") if iso else "")
+        return _completed("")
+    return fake_run
+
+
+def test_stale_file_flagged_fresh_file_ignored(tmp_path):
+    (tmp_path / "fresh.md").write_text("x", encoding="utf-8")
+    (tmp_path / "stale.md").write_text("y", encoding="utf-8")
+
+    side_effect = _git_mock(
+        str(tmp_path),
+        {"fresh.md": _iso(10), "stale.md": _iso(400)},
+    )
+    with mock.patch.object(staleness.subprocess, "run", side_effect=side_effect):
+        result = staleness.run(str(tmp_path))
+
+    files = [r["file"] for r in result]
+    assert any(f.endswith("stale.md") for f in files)
+    assert not any(f.endswith("fresh.md") for f in files)
+
+    stale = next(r for r in result if r["file"].endswith("stale.md"))
+    assert stale["days_since"] >= 399  # ~400, allow for clock skew
+    # last_modified is an ISO date string (YYYY-MM-DD)
+    datetime.strptime(stale["last_modified"], "%Y-%m-%d")
+
+
+def test_boundary_exactly_180_days_is_not_stale(tmp_path):
+    (tmp_path / "edge.md").write_text("z", encoding="utf-8")
+
+    side_effect = _git_mock(str(tmp_path), {"edge.md": _iso(180)})
+    with mock.patch.object(staleness.subprocess, "run", side_effect=side_effect):
+        result = staleness.run(str(tmp_path))
+
+    # Threshold is strictly "> 180 days", so exactly 180 is still fresh.
+    assert result == []
+
+
+def test_file_without_git_history_is_skipped(tmp_path):
+    (tmp_path / "new.md").write_text("z", encoding="utf-8")
+
+    side_effect = _git_mock(str(tmp_path), {"new.md": None})  # empty git log
+    with mock.patch.object(staleness.subprocess, "run", side_effect=side_effect):
+        assert staleness.run(str(tmp_path)) == []
+
+
+def test_not_a_git_repo_returns_empty(tmp_path):
+    (tmp_path / "a.md").write_text("z", encoding="utf-8")
+
+    def boom(cmd, *args, **kwargs):
+        raise CalledProcessError(128, cmd)
+
+    with mock.patch.object(staleness.subprocess, "run", side_effect=boom):
+        assert staleness.run(str(tmp_path)) == []

--- a/tests/test_todo_scan.py
+++ b/tests/test_todo_scan.py
@@ -1,0 +1,73 @@
+"""Tests for the TODO / FIXME / XXX scanner.
+
+Casing policy under test (hybrid):
+* TODO / FIXME — case-insensitive, normalised to upper-case in output.
+* XXX          — upper-case only (lower-case ``xxx`` is ignored).
+"""
+
+from checkers import todo_scan
+
+
+def _md(tmp_path, text, name="a.md"):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_detects_all_uppercase_markers(tmp_path):
+    _md(tmp_path, "- TODO: wire cache\n- FIXME race here\n- XXX hack\n")
+
+    markers = sorted(r["marker"] for r in todo_scan.run(str(tmp_path)))
+
+    assert markers == ["FIXME", "TODO", "XXX"]
+
+
+def test_todo_and_fixme_are_case_insensitive(tmp_path):
+    _md(tmp_path, "a lowercase todo line\nthis is a fixme thing\nMixed FixMe\n")
+
+    markers = sorted(r["marker"] for r in todo_scan.run(str(tmp_path)))
+
+    # All normalised to canonical upper-case.
+    assert markers == ["FIXME", "FIXME", "TODO"]
+
+
+def test_xxx_is_case_sensitive(tmp_path):
+    _md(tmp_path, "lowercase xxx should be ignored\nUPPER XXX is kept\n")
+
+    result = todo_scan.run(str(tmp_path))
+
+    assert [r["marker"] for r in result] == ["XXX"]
+    assert result[0]["line"] == 2
+
+
+def test_context_is_captured_and_trimmed(tmp_path):
+    _md(tmp_path, "   TODO: implement the retry backoff   \n")
+
+    result = todo_scan.run(str(tmp_path))
+
+    assert result[0]["context"] == "TODO: implement the retry backoff"
+    assert result[0]["line"] == 1
+    assert result[0]["file"].endswith("a.md")
+
+
+def test_code_fences_and_call_forms_are_skipped(tmp_path):
+    _md(
+        tmp_path,
+        "```go\nctx := context.TODO()\n```\n"   # fenced -> skipped
+        "bare := context.TODO()\n"               # `TODO(` call form -> skipped
+        "real TODO: do this\n",                  # the only real marker
+    )
+
+    result = todo_scan.run(str(tmp_path))
+
+    assert len(result) == 1
+    assert result[0]["marker"] == "TODO"
+    assert "real TODO" in result[0]["context"]
+
+
+def test_multiple_markers_on_one_line(tmp_path):
+    _md(tmp_path, "TODO and also FIXME on the same line\n")
+
+    markers = sorted(r["marker"] for r in todo_scan.run(str(tmp_path)))
+
+    assert markers == ["FIXME", "TODO"]


### PR DESCRIPTION
## Document Agent Proof-of-Concept

This PR introduces a working proof-of-concept for the **Document Agent** proposed in #316. Rather than describing an approach, this PR ships runnable code with real output.

I'm submitting this as part of my LFX Mentorship Term 2 application — happy to receive feedback on the direction before finalizing the proposal.

## What this PoC does

| Step | Action |
| ---- | ------ |
| 1 | Fetches the latest release for each tracked OpenKruise sub-project via the public GitHub Releases API |
| 2 | Extracts the latest release tag, publish date, and changelog body |
| 3 | Evaluates **documentation freshness** — flags any release older than 30 days as `STALE` |
| 4 | Auto-generates Docusaurus-compatible blog posts from release changelogs (with prose fallback for sparse release bodies) |
| 5 | Writes a consolidated freshness report across all sub-projects |
| 6 | Runs on a weekly schedule and on manual trigger via GitHub Actions |

Tracked sub-projects: `kruise`, `rollouts`, `kruise-game`, `kruise-rollout-api`.

## Sample output — freshness report

The agent currently flags every sub-project as STALE, which is a real finding worth surfacing for documentation maintainers:

| Sub-Project | Latest Version | Release Date | Days Since Release | Status |
| ----------- | -------------- | ------------ | ------------------ | ------ |
| Kruise | v1.8.3 | 2026-02-25 | 81 | 🔴 STALE |
| Rollouts | v0.6.2 | 2025-12-22 | 146 | 🔴 STALE |
| Kruise-Game | v1.0.0 | 2025-07-21 | 300 | 🔴 STALE |
| Kruise-Rollout-API | v0.6.0 | 2025-02-06 | 465 | 🔴 STALE |

## Sample output — auto-generated blog post

title: “OpenKruise Kruise v1.8.3 Released”
date: 2026-02-25
author: OpenKruise Community
tags: [kruise, release]
What’s New in v1.8.3

- restrict host field in probe (#2309) by @furykerry in https://github.com/openkruise/kruise/pull/2372

For the full changelog, see the release notes.


## Design choices

- Generated files are written to `agent-output/` (a staging directory), **not** directly into the live `blog/` folder — maintainers retain full control over what gets published.
- Zero authentication required. Stays well within the 60 req/hour unauthenticated GitHub API budget (the agent uses 4 requests per run).
- Only one third-party dependency (`requests`); everything else is stdlib.
- Sparse release bodies are handled gracefully via a prose fallback so no blog post is ever empty.
- `AGENTS.md` documents how the agent works, the tools it uses, and how to run it.

## How to run locally

```bash
pip install requests
python scripts/doc_agent.py


Files added

- 	scripts/doc_agent.py — the agent itself
- 	AGENTS.md — agent documentation
- 	.github/workflows/doc-agent.yml — scheduled + manual trigger workflow
- 	agent-output/ — example output (freshness report + 4 generated blog posts)

Proposed mentorship roadmap (full term)
If selected for the mentorship, I would extend this PoC across three phases:

1. Phase 1 — Content collection & freshness evaluation (this PoC, hardened)
2. Phase 2 — RAG-based cross-reference detection for detecting stale doc links and outdated examples across the docs site
3. Phase 3 — MCP tooling integration for metadata enrichment and automated PR creation back into the docs

Relates to #316