### PR TITLE
docs: fix broken introduction links and stale installation image tags

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,7 +121,7 @@ The following table lists the configurable parameters of the chart and their def
 | `manager.log.level`                 | Log level that kruise-manager printed                          | `4`                         |
 | `manager.replicas`                  | Replicas of kruise-controller-manager deployment               | `2`                         |
 | `manager.image.repository`          | Repository for kruise-manager image                            | `openkruise/kruise-manager` |
-| `manager.image.tag`                 | Tag for kruise-manager image                                   | `v1.8.0`                    |
+| `manager.image.tag`                 | Tag for kruise-manager image                                   | `v1.9.0`                    |
 | `manager.resources.limits.cpu`      | CPU resource limit of kruise-manager container                 | `200m`                      |
 | `manager.resources.limits.memory`   | Memory resource limit of kruise-manager container              | `512Mi`                     |
 | `manager.resources.requests.cpu`    | CPU resource request of kruise-manager container               | `100m`                      |

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation.md
@@ -108,7 +108,7 @@ feature-gates。
 | `manager.log.level`                 | kruise-manager 日志输出级别                             | `4`                         |
 | `manager.replicas`                  | kruise-manager 的期望副本数                             | `2`                         |
 | `manager.image.repository`          | kruise-manager/kruise-daemon 镜像仓库                 | `openkruise/kruise-manager` |
-| `manager.image.tag`                 | kruise-manager/kruise-daemon 镜像版本                 | `1.8.0`                     |
+| `manager.image.tag`                 | kruise-manager/kruise-daemon 镜像版本                 | `v1.9.0`                    |
 | `manager.resources.limits.cpu`      | kruise-manager 的 limit CPU 资源                     | `200m`                      |
 | `manager.resources.limits.memory`   | kruise-manager 的 limit memory 资源                  | `512Mi`                     |
 | `manager.resources.requests.cpu`    | kruise-manager 的 request CPU 资源                   | `100m`                      |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/introduction.md
@@ -65,5 +65,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/introduction.md
@@ -56,5 +56,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/introduction.md
@@ -56,5 +56,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/installation.md
@@ -108,7 +108,7 @@ feature-gates。
 | `manager.log.level`                 | kruise-manager 日志输出级别                             | `4`                         |
 | `manager.replicas`                  | kruise-manager 的期望副本数                             | `2`                         |
 | `manager.image.repository`          | kruise-manager/kruise-daemon 镜像仓库                 | `openkruise/kruise-manager` |
-| `manager.image.tag`                 | kruise-manager/kruise-daemon 镜像版本                 | `1.7.2`                     |
+| `manager.image.tag`                 | kruise-manager/kruise-daemon 镜像版本                 | `v1.9.0`                    |
 | `manager.resources.limits.cpu`      | kruise-manager 的 limit CPU 资源                     | `200m`                      |
 | `manager.resources.limits.memory`   | kruise-manager 的 limit memory 资源                  | `512Mi`                     |
 | `manager.resources.requests.cpu`    | kruise-manager 的 request CPU 资源                   | `100m`                      |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/introduction.md
@@ -56,5 +56,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/versioned_docs/version-v1.7/introduction.md
+++ b/versioned_docs/version-v1.7/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/versioned_docs/version-v1.8/introduction.md
+++ b/versioned_docs/version-v1.8/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/versioned_docs/version-v1.9/installation.md
+++ b/versioned_docs/version-v1.9/installation.md
@@ -121,7 +121,7 @@ The following table lists the configurable parameters of the chart and their def
 | `manager.log.level`                 | Log level that kruise-manager printed                          | `4`                         |
 | `manager.replicas`                  | Replicas of kruise-controller-manager deployment               | `2`                         |
 | `manager.image.repository`          | Repository for kruise-manager image                            | `openkruise/kruise-manager` |
-| `manager.image.tag`                 | Tag for kruise-manager image                                   | `v1.8.0`                    |
+| `manager.image.tag`                 | Tag for kruise-manager image                                   | `v1.9.0`                    |
 | `manager.resources.limits.cpu`      | CPU resource limit of kruise-manager container                 | `200m`                      |
 | `manager.resources.limits.memory`   | Memory resource limit of kruise-manager container              | `512Mi`                     |
 | `manager.resources.requests.cpu`    | CPU resource request of kruise-manager container               | `100m`                      |

--- a/versioned_docs/version-v1.9/introduction.md
+++ b/versioned_docs/version-v1.9/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).


### PR DESCRIPTION
### Summary

This PR bundles together two important documentation fixes to ensure everything is accurate and working, specifically focusing on the versioned documentation:

### Changes made : 

**1. Broken "What's Next" links:** The links at the bottom of the `introduction.md` pages were pointing to incorrect relative paths (`./docs/...`), causing 404 errors in the versioned docs (v1.7, v1.8, v1.9). This updates them to resolve correctly across all versions.

**2.  Helm image tags:** The `installation.md` explicitly instructed users to install `1.9.0`, but the configuration table just below it still incorrectly referenced the older `v1.8.0` (and `1.7.2` in the Chinese docs). This aligns the tables to `v1.9.0` to avoid user confusion.

These fixes were carefully applied to the English and Chinese (`i18n`) docs, including all relevant older versions (`v1.7` through `v1.9`) where these issues were present.