### PR TITLE
docs(kruiseagents): add E2B URL parameters for in-cluster access

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/e2b-client.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/e2b-client.md
@@ -110,7 +110,43 @@ kubectl create secret tls sandbox-manager-tls \
 3. 在您的 DNS 提供商处将单个域名 `your.domain.com` 解析到 sandbox-manager 的 ingress 端点
 4. 安装单个域名证书 `your.domain.com`
 
-### 3. 私有协议集群内访问
+### 3. 使用 E2B URL 参数实现集群内访问
+
+> 通过 E2B SDK 原生支持的 URL 参数直接连接集群内的 sandbox-manager，无需域名、证书或私有协议 patch。要求 `e2b >= 2.7.0`。
+
+1. 确保客户端（agent）和 sandbox-manager 在同一集群中。
+2. 客户端配置环境变量：
+    ```shell
+    export E2B_API_URL="http://sandbox-manager.sandbox-system.svc.cluster.local:8080"
+    # 如果未安装外置的流量网关 sandbox-gateway，可以将下方 service 替换为 sandbox-manager
+    # 以继续使用 sandbox-manager 内置的流量代理（不推荐）
+    export E2B_SANDBOX_URL="http://sandbox-gateway.sandbox-system.svc.cluster.local:7788"
+    export E2B_API_KEY=<your-api-key>
+    ```
+3. 使用 E2B SDK 创建 Sandbox，无需额外 patch：
+    ```python
+    from e2b import Sandbox
+
+    # E2B_API_URL 和 E2B_SANDBOX_URL 会自动从环境变量读取
+    sandbox = Sandbox()
+    print(sandbox.get_host(8000))  # 获取 Sandbox 内服务的访问地址
+    sandbox.kill()
+    ```
+
+> ⚠️ **限制说明**：上层库 `e2b-code-interpreter` 和 `e2b-desktop` 的以下扩展功能不读取 `E2B_API_URL` / `E2B_SANDBOX_URL` 环境变量，因此不支持此接入方式：
+>
+> **e2b-code-interpreter：**
+> - `Sandbox.run_code`
+> - `Sandbox.create_code_context`
+> - `Sandbox.remove_code_context`
+> - `Sandbox.list_code_contexts`
+> - `Sandbox.restart_code_context`
+>
+> **e2b-desktop：**
+> - `desktop.stream.get_url`
+> - `desktop.stream.start`
+
+### 4. 私有协议集群内访问
 
 > 这种方式可以快速自动化部署，无需配置域名和证书。仅推荐用于 E2E 测试场景，或经过严格评估后使用。
 
@@ -127,7 +163,7 @@ kubectl create secret tls sandbox-manager-tls \
     patch_e2b(https=False)
     ```
 
-### 4. 端口转发 sandbox-manager 到本地机器
+### 5. 端口转发 sandbox-manager 到本地机器
 
 1. 客户端配置环境变量：
     ```shell

--- a/kruiseagents/user-manuals/e2b-client.md
+++ b/kruiseagents/user-manuals/e2b-client.md
@@ -117,7 +117,43 @@ kubectl create secret tls sandbox-manager-tls \
 3. Resolve single domain `your.domain.com` to sandbox-manager ingress endpoint with your DNS provider
 4. Install single domain certificate `your.domain.com`
 
-### 3. Private protocol in-cluster access
+### 3. In-cluster access using E2B URL parameters
+
+> Connect to sandbox-manager within the cluster using E2B SDK's native URL parameters — no domain, certificate, or private protocol patch required. Requires `e2b >= 2.7.0`.
+
+1. Ensure the client (agent) and sandbox-manager are in the same cluster.
+2. Client configuration environment variables:
+    ```shell
+    export E2B_API_URL="http://sandbox-manager.sandbox-system.svc.cluster.local:8080"
+    # If the external traffic gateway sandbox-gateway is not installed, you can replace the service below with sandbox-manager
+    # to continue using sandbox-manager's built-in traffic proxy (not recommended)
+    export E2B_SANDBOX_URL="http://sandbox-gateway.sandbox-system.svc.cluster.local:7788"
+    export E2B_API_KEY=<your-api-key>
+    ```
+3. Create a Sandbox using the E2B SDK — no additional patching required:
+    ```python
+    from e2b import Sandbox
+
+    # E2B_API_URL and E2B_SANDBOX_URL are automatically read from environment variables
+    sandbox = Sandbox()
+    print(sandbox.get_host(8000))  # Get the access URL for a service inside the Sandbox
+    sandbox.kill()
+    ```
+
+> ⚠️ **Limitation**: The following extended features in the upper-level libraries `e2b-code-interpreter` and `e2b-desktop` do not read the `E2B_API_URL` / `E2B_SANDBOX_URL` environment variables, and therefore do not support this access method:
+>
+> **e2b-code-interpreter:**
+> - `Sandbox.run_code`
+> - `Sandbox.create_code_context`
+> - `Sandbox.remove_code_context`
+> - `Sandbox.list_code_contexts`
+> - `Sandbox.restart_code_context`
+>
+> **e2b-desktop:**
+> - `desktop.stream.get_url`
+> - `desktop.stream.start`
+
+### 4. Private protocol in-cluster access
 
 > This approach enables rapid automated deployment without requiring domain and certificate configuration. Recommended
 > for E2E testing scenarios only, or after rigorous evaluation.
@@ -135,7 +171,7 @@ kubectl create secret tls sandbox-manager-tls \
     patch_e2b(https=False)
     ```
 
-### 4. Port forward sandbox-manager to local machine
+### 5. Port forward sandbox-manager to local machine
 
 1. Client configuration environment variables:
     ```shell


### PR DESCRIPTION
## Summary

Add a new section 3 — "In-cluster access using E2B URL parameters" — to the recommended sandbox-manager integration methods (Chinese & English), placed before "Private protocol in-cluster access".

## Changes

- Document `E2B_API_URL` and `E2B_SANDBOX_URL` environment variables for native in-cluster access (requires `e2b >= 2.7.0`)
- Note that `E2B_SANDBOX_URL` can fall back to the sandbox-manager service when the external traffic gateway (sandbox-gateway) is not installed (not recommended)
- Provide a Python code example
- Add limitation notes for `e2b-code-interpreter` and `e2b-desktop` upper-level libraries that do not read these URL environment variables
- Renumber existing sections 3 → 4, 4 → 5

## Affected Files

- `kruiseagents/user-manuals/e2b-client.md` (English)
- `i18n/zh/.../user-manuals/e2b-client.md` (Chinese)