### PR TITLE
docs: add E2B SDK >=2.25.0 key format compatibility guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+## Git Requirements
+
+- All commit messages and PR descriptions **must be written in English**.
+- All commits **must be signed off** (`git commit -s`). The sign-off certifies that you have the right to submit the contribution under the project's open-source license.
+- Never use force push (`--force`, `--force-with-lease`) on the main branch or any shared branch.
+- Never use destructive git commands (hard reset, rebase --abort after conflicts resolved, etc.) unless explicitly requested.

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/api-keys-and-teams.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/api-keys-and-teams.md
@@ -78,6 +78,7 @@ API Key 决定了：
 | `GET`    | `/teams`         | 列出当前用户可见的 Team                                       |
 | `GET`    | `/api-keys`      | 列出当前用户所属 Team 的所有 API Key                            |
 | `POST`   | `/api-keys`      | 为当前用户所属 Team 创建 API Key（管理员可以为其他 Team 创建）            |
+| `GET`    | `/api-keys/compatible` | 获取当前 API Key 的 E2B SDK 兼容格式（从 **v0.4.0** 起支持）   |
 | `DELETE` | `/api-keys/{id}` | 按 UUID 删除 API Key                                    |
 
 所有请求都必须带上请求头 `X-API-KEY: <your-api-key>`。
@@ -245,6 +246,102 @@ resp.raise_for_status()
 
   </TabItem>
 </Tabs>
+
+## E2B SDK Key 格式兼容性
+
+:::info 版本支持
+本节描述的兼容性功能从 **v0.4.0** 版本开始支持。
+:::
+
+### 背景
+
+从 **E2B SDK >= 2.25.0** 开始，SDK 在发送请求之前会对 API Key 进行客户端格式校验，仅接受匹配 `e2b_[0-9a-f]+`
+模式的 Key。不符合该格式的 Key——例如老版本的 UUID 格式 Key 或用户自定义的 admin Key（如 `admin-987654321`）——会在到达服务端之前
+就被 SDK **直接拒绝**。
+
+为此，`sandbox-manager` v0.4.0 引入了兼容层，将原始 Key 编码为 SDK 兼容的 `e2b_...` 格式，同时服务端的存储与鉴权语义完全不变。
+
+### 增量 Key（v0.4.0+）
+
+从 **v0.4.0** 起，`POST /api-keys` 返回的所有 API Key 已自动编码为 `e2b_[0-9a-f]+` 格式，无需任何额外操作——新 Key
+同时兼容新旧版本的 E2B SDK。
+
+### 存量 Key（v0.4.0 之前）
+
+v0.4.0 之前创建的 API Key（包括用户自定义的 admin Key）仍然完全有效。存量 Key 与新的 SDK 兼容 Key **功能上完全等价**——它们
+鉴权到的是同一份凭证，授权行为没有任何差异。你可以继续在旧版 E2B SDK（< 2.25.0）上使用存量 Key，不存在任何兼容性问题。
+
+如需在 E2B SDK >= 2.25.0 上使用存量 Key，有以下三种方式：
+
+#### 方式一：通过 API 获取兼容 Key
+
+使用现有 Key 调用新增的 `GET /api-keys/compatible` 接口，响应会返回当前凭证的 SDK 兼容 `e2b_...` 形式：
+
+<Tabs>
+  <TabItem value="curl" label="curl">
+
+```shell
+curl -sS \
+  -H "X-API-KEY: ${E2B_API_KEY}" \
+  "https://api.your.domain.com/api-keys/compatible"
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python requests">
+
+```python
+import os
+import requests
+
+resp = requests.get(
+    "https://api.your.domain.com/api-keys/compatible",
+    headers={"X-API-KEY": os.environ["E2B_API_KEY"]},
+    timeout=10,
+)
+resp.raise_for_status()
+print(resp.json()["key"])  # e2b_...
+```
+
+  </TabItem>
+</Tabs>
+
+将老 Key 替换为返回的 `e2b_...` Key 即可。两种形式鉴权到的是同一份凭证。
+
+#### 方式二：通过 `keys.py` 本地转换
+
+如果不方便调用 API，可以使用
+[`keys.py`](https://github.com/openkruise/agents/blob/master/sdk/customized_e2b/kruise_agents/keys.py)
+工具在本地将存量 Key 转换为兼容格式：
+
+```python
+from keys import encode_for_e2b_sdk
+
+compatible_key = encode_for_e2b_sdk("your-legacy-key")
+print(compatible_key)  # e2b_6f6b616701...
+```
+
+> 本地转换的结果与服务端返回的编码 Key 完全一致。该转换是确定性的，不需要网络访问。
+
+#### 方式三：通过 `patch_e2b` 禁用 SDK Key 校验
+
+在使用 OpenKruise Agents 私有协议时（参见 [E2B SDK 接入文档](./e2b-client.md)），可以向 `patch_e2b` 传入
+`validate_key=False` 来完全跳过 SDK 侧的 Key 格式校验：
+
+```python
+from kruise_agents.patch_e2b import patch_e2b
+patch_e2b(https=True, validate_key=False)
+```
+
+这样存量 Key 无需转换即可直接使用。该方式仅适用于 E2B SDK >= 2.25.0。
+
+### Key 等价性
+
+存量原始 Key 与 SDK 兼容的 `e2b_...` Key **完全等价、可互换使用**：
+
+- 两种形式在服务端鉴权到的是同一份凭证。
+- 两种形式均可在 E2B SDK < 2.25.0 上正常使用（该版本不做客户端 Key 格式校验）。
+- 服务端同时接受两种形式的 `X-API-KEY` 请求头——对于 `e2b_...` 格式的 Key，服务端会透明地解码回原始 Key 后再查找存储。
+- 无需对存量 Key 做任何迁移，可以按自己的节奏逐步采用新格式。
 
 ## 错误码
 

--- a/kruiseagents/user-manuals/api-keys-and-teams.md
+++ b/kruiseagents/user-manuals/api-keys-and-teams.md
@@ -84,6 +84,7 @@ accordingly. For example `GET /api-keys` becomes `GET https://your.domain.com/kr
 | `GET`    | `/teams`              | List teams the current user can see                        |
 | `GET`    | `/api-keys`           | List API keys owned by the current user's team             |
 | `POST`   | `/api-keys`           | Create a new API key for the current user's team (or another team if admin) |
+| `GET`    | `/api-keys/compatible`| Get the E2B SDK-compatible form of the current API key (since **v0.4.0**) |
 | `DELETE` | `/api-keys/{id}`      | Delete the API key with the given UUID                     |
 
 Every request must set the header `X-API-KEY: <your-api-key>`.
@@ -252,6 +253,109 @@ resp.raise_for_status()
 
   </TabItem>
 </Tabs>
+
+## E2B SDK Key Format Compatibility
+
+:::info Version
+The compatibility features described in this section are available since **v0.4.0**.
+:::
+
+### Background
+
+Starting from **E2B SDK >= 2.25.0**, the SDK performs client-side validation on API keys before sending any request.
+Only keys matching the pattern `e2b_[0-9a-f]+` are accepted. Keys that do not match this format — such as legacy
+UUID keys or custom admin keys like `admin-987654321` — are rejected by the SDK **before** they ever reach the server.
+
+To address this, `sandbox-manager` v0.4.0 introduces a compatibility layer that encodes raw API keys into the
+SDK-compatible `e2b_...` format while keeping the server-side storage and authentication semantics completely unchanged.
+
+### New Keys (v0.4.0+)
+
+Starting from **v0.4.0**, all API keys returned by `POST /api-keys` are automatically encoded in the
+`e2b_[0-9a-f]+` format. No additional action is required — new keys work with both old and new E2B SDK versions
+out of the box.
+
+### Legacy Keys (Pre-v0.4.0)
+
+API keys created before v0.4.0 (including user-defined admin keys) remain fully valid. These legacy keys are
+**functionally equivalent** to the new SDK-compatible keys — they authenticate to the same credential and have no
+difference in authorization behavior. You can continue using legacy keys with older E2B SDK versions (< 2.25.0)
+without any compatibility issues.
+
+If you need to use legacy keys with E2B SDK >= 2.25.0, there are three options:
+
+#### Option 1: Retrieve a Compatible Key via API
+
+Call the new `GET /api-keys/compatible` endpoint with your existing key. The response returns the SDK-compatible
+`e2b_...` form of your current credential:
+
+<Tabs>
+  <TabItem value="curl" label="curl">
+
+```shell
+curl -sS \
+  -H "X-API-KEY: ${E2B_API_KEY}" \
+  "https://api.your.domain.com/api-keys/compatible"
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python requests">
+
+```python
+import os
+import requests
+
+resp = requests.get(
+    "https://api.your.domain.com/api-keys/compatible",
+    headers={"X-API-KEY": os.environ["E2B_API_KEY"]},
+    timeout=10,
+)
+resp.raise_for_status()
+print(resp.json()["key"])  # e2b_...
+```
+
+  </TabItem>
+</Tabs>
+
+Replace your old key with the returned `e2b_...` key. Both forms authenticate to the same underlying credential.
+
+#### Option 2: Local Conversion via `keys.py`
+
+For environments where calling the API is not convenient, you can convert legacy keys locally using the
+[`keys.py`](https://github.com/openkruise/agents/blob/master/sdk/customized_e2b/kruise_agents/keys.py) utility:
+
+```python
+from keys import encode_for_e2b_sdk
+
+compatible_key = encode_for_e2b_sdk("your-legacy-key")
+print(compatible_key)  # e2b_6f6b616701...
+```
+
+> This produces the exact same encoded key that the server would return. The conversion is deterministic and does
+> not require network access.
+
+#### Option 3: Disable SDK Key Validation via `patch_e2b`
+
+When using the OpenKruise Agents private protocol (see [E2B SDK integration](./e2b-client.md)), you can disable
+the SDK-side key validation entirely by passing `validate_key=False` to `patch_e2b`:
+
+```python
+from kruise_agents.patch_e2b import patch_e2b
+patch_e2b(https=True, validate_key=False)
+```
+
+This skips the E2B SDK key format check so that legacy keys can be used as-is. This approach only works with
+E2B SDK >= 2.25.0.
+
+### Key Equivalence
+
+Legacy raw keys and SDK-compatible `e2b_...` keys are **fully interchangeable**:
+
+- Both forms authenticate to the same underlying credential on the server.
+- Both forms work with E2B SDK < 2.25.0 (which does not perform client-side key validation).
+- The server accepts either form in the `X-API-KEY` header — it transparently decodes `e2b_...` keys back to the
+  raw key before looking up storage.
+- No migration of existing keys is required. You can adopt the new format at your own pace.
 
 ## Error Handling
 


### PR DESCRIPTION
## Background

E2B SDK >= 2.25.0 introduces client-side API key format validation before any request is sent.
Only keys matching the `e2b_[0-9a-f]+` pattern are accepted. Legacy keys that do not conform to
this format — such as UUID-style keys or custom admin keys like `admin-987654321` — are rejected
by the SDK **before** they ever reach the server.

## Changes

Add a new **E2B SDK Key Format Compatibility** section (EN + ZH) to `api-keys-and-teams.md`, covering:

1. **New keys (v0.4.0+)**: All keys returned by `POST /api-keys` are automatically encoded in the
   SDK-compatible format — no action required.
2. **Legacy key migration** (three options):
   - Call the new `GET /api-keys/compatible` endpoint to retrieve the compatible form
   - Use [`keys.py`](https://github.com/openkruise/agents/blob/master/sdk/customized_e2b/kruise_agents/keys.py) for offline local conversion
   - Pass `patch_e2b(https=True, validate_key=False)` to disable SDK-side key validation
3. **Key equivalence**: Legacy raw keys and new `e2b_...` keys are fully interchangeable —
   they authenticate to the same credential, work with all SDK versions, and require no migration.

Also add `GET /api-keys/compatible` to the endpoints table.

## Files Changed

- `kruiseagents/user-manuals/api-keys-and-teams.md` (English)
- `i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/api-keys-and-teams.md` (Chinese)
- `AGENTS.md` (project-level agent conventions)