### PR TITLE
docs: fix broken markdown links to improve GitHub navigation

### DIFF
--- a/docs/core-concepts/inplace-update.md
+++ b/docs/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ In-place Update is one of the key features provided by OpenKruise.
 
 Workloads that support in-place update:
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 Currently `CloneSet`, `Advanced StatefulSet` and `Advanced DaemonSet` reuse the same code package [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) and have similar behaviors of in-place update. In this article, we would like to introduce the usage and workflow of them.
 
@@ -90,7 +90,7 @@ You can see the whole workflow of in-place update below (*you may need to right 
 
 **FEATURE STATE:** Kruise v1.1.0
 
-When you in-place update multiple containers at once and the containers have different [launch priorities](/docs/user-manuals/containerlaunchpriority),
+When you in-place update multiple containers at once and the containers have different [launch priorities](../user-manuals/containerlaunchpriority.md),
 Kruise will update the containers by order according to the priorities.
 
 - For pods without container launch priorities, no guarantees of the execution order during in-place update multiple containers.

--- a/docs/user-manuals/resourcedistribution.md
+++ b/docs/user-manuals/resourcedistribution.md
@@ -233,4 +233,4 @@ In particular, we **DO NOT** recommend that users bypass the ResourceDistributio
 
 ## Kustomize ResourceDistribution Generator
 
-ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](/docs/next/cli-tool/kustomize-plugin) for details.
+ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](../cli-tool/kustomize-plugin.md) for details.

--- a/docs/user-manuals/sidecarset.md
+++ b/docs/user-manuals/sidecarset.md
@@ -436,7 +436,7 @@ spec:
 
 SidecarSet supports configuring sidecar container resources based on pod specifications during pod creation.
 
-For design documentation, please refer to: [proposals sidecarset dynamic resources when pod creating](https://github.com/openkruise/kruise/blob/master/docs/proposals/20250913-sidecarset-dynamic-resources-when-creating.md). Best practice: [Dynamic Resource Injection with SidecarSet](docs/best-practices/resource-policy-sidecarset.md)
+For design documentation, please refer to: [proposals sidecarset dynamic resources when pod creating](https://github.com/openkruise/kruise/blob/master/docs/proposals/20250913-sidecarset-dynamic-resources-when-creating.md). Best practice: [Dynamic Resource Injection with SidecarSet](../best-practices/resource-policy-sidecarset.md)
 
 ```yaml
 apiVersion: apps.kruise.io/v1beta1
@@ -703,8 +703,8 @@ spec:
 
 **Note:**
 - k8s 1.28 feature-gate SidecarContainers is off by default and needs to be actively turned on, k8s 1.29 is on by default.
-- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-and [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) to solve the above problem.
+- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](./jobsidecarterminator.md)
+and [Container Launch Priority](./containerlaunchpriority.md) to solve the above problem.
 
 **Additionally, the current version only supports automatic injection of Sidecar Containers, and does not yet support in-place update capability.**
 

--- a/i18n/zh/docusaurus-plugin-content-blog/2021-12-13-release-1.0.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2021-12-13-release-1.0.md
@@ -70,7 +70,7 @@ spec:
 
 *与此同时，我们在这个版本中也去除了过去对镜像原地升级的`imageID`限制，即支持相同imageID的两个镜像替换升级。*
 
-具体使用方式请参考[文档](/docs/core-concepts/inplace-update)。
+具体使用方式请参考[文档](https://openkruise.io/docs/core-concepts/inplace-update)。
 
 ### 2. 配置跨命名空间分发
 
@@ -107,7 +107,7 @@ spec:
 
 如上述 YAML 所示，ResourceDistribution是一类 **cluster-scoped** 的 CRD，其主要由 **`resource`** 和 **`targets`** 两个字段构成，其中 **`resource`** 字段用于描述用户所要分发的资源，**`targets`** 字段用于描述用户所要分发的目标命名空间。
 
-具体使用方式请参考[文档](/docs/user-manuals/resourcedistribution)。
+具体使用方式请参考[文档](https://openkruise.io/docs/user-manuals/resourcedistribution)。
 
 ### 3. 容器启动顺序控制
 
@@ -124,7 +124,7 @@ spec:
 1. 对于任意一个 Pod 对象，只需要在 annotations 中定义 `apps.kruise.io/container-launch-priority: Ordered`，则 Kruise 会按照 Pod 中 `containers` 容器列表的顺序来保证其中容器的串行启动。
 2. 如果要自定义 `containers` 中多个容器的启动顺序，则在容器 env 中添加 `KRUISE_CONTAINER_PRIORITY` 环境变量，value 值是范围在 `[-2147483647, 2147483647]` 的整数。一个容器的 priority 值越大，会保证越先启动。
 
-具体使用方式请参考[文档](/docs/user-manuals/containerlaunchpriority)。
+具体使用方式请参考[文档](https://openkruise.io/docs/user-manuals/containerlaunchpriority)。
 
 ### 4. `kubectl-kruise` 命令行工具
 
@@ -147,7 +147,7 @@ $ kubectl kruise rollout status statefulsets.apps.kruise.io/sts-demo
 $ kubectl kruise set image cloneset/nginx busybox=busybox nginx=nginx:1.9.1
 ```
 
-具体使用方式请参考[文档](/docs/cli-tool/kubectl-plugin)。
+具体使用方式请参考[文档](https://openkruise.io/docs/cli-tool/kubectl-plugin)。
 
 ### 5. 其余部分功能改进与优化
 

--- a/i18n/zh/docusaurus-plugin-content-blog/2022-03-29-release-1.1.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2022-03-29-release-1.1.md
@@ -19,7 +19,7 @@ tags: [release]
 
 ### 1. 原地升级支持容器顺序优先级
 
-去年底发布的 v1.0 版本，OpenKruise 引入了[容器启动顺序控制](/docs/user-manuals/containerlaunchpriority/)功能，
+去年底发布的 v1.0 版本，OpenKruise 引入了[容器启动顺序控制](https://openkruise.io/docs/user-manuals/containerlaunchpriority/)功能，
 它支持为一个 Pod 中的多个容器定义不同的权重关系，并在 Pod 创建时按照权重来控制不同容器的启动顺序。
 
 在 v1.0 中，这个功能仅仅能够作用于每个 Pod 的创建阶段。当创建完成后，如果对 Pod 中多个容器做原地升级，则这些容器都会被同时执行升级操作。
@@ -32,7 +32,7 @@ tags: [release]
 在实际使用过程中，用户无需配置任何额外参数，只要 Pod 在创建时已经带有了容器启动优先级，则不仅在 Pod 创建阶段，会保证高优先级容器先于低优先级容器启动；
 并且在**单次原地升级**中，如果同时升级了多个容器，会先升级高优先级容器，等待它升级启动完成后，再升级低优先级容器。
 
-**这里的原地升级，包括修改 image 镜像升级与修改 env from metadata 的环境变量升级，详见[原地升级介绍](/docs/core-concepts/inplace-update)）**
+**这里的原地升级，包括修改 image 镜像升级与修改 env from metadata 的环境变量升级，详见[原地升级介绍](https://openkruise.io/docs/core-concepts/inplace-update)）**
 
 总结来说
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ title: 原地升级
 
 目前支持原地升级的 Workload：
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 目前 `CloneSet`、`Advanced StatefulSet`、`Advanced DaemonSet` 是复用的同一个代码包 [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) 并且有类似的原地升级行为。在本文中，我们会介绍它的用法和工作流程。
 
@@ -90,7 +90,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-当你同时原地升级多个具有不同[启动顺序](/docs/user-manuals/containerlaunchpriority)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
+当你同时原地升级多个具有不同[启动顺序](../user-manuals/containerlaunchpriority.md)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
 
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。
 - 对于存在容器启动顺序的 Pod：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/sidecarset.md
@@ -694,8 +694,8 @@ spec:
 
 **注意：**
 - k8s 1.28 feature-gate SidecarContainers 默认是关闭的需要主动打开，k8s 1.29 是默认开启的。
-- 如果 K8S 版本\<1.28，你可以使用 Kruise 提供的 [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-和 [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) 来解决上述问题。
+- 如果 K8S 版本\<1.28，你可以使用 Kruise 提供的 [Job Sidecar Terminator](./jobsidecarterminator.md)
+和 [Container Launch Priority](./containerlaunchpriority.md) 来解决上述问题。
 
 **此外，当前版本只支持 Sidecar Containers 自动注入，暂时还不支持原地升级能力。**
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ title: 原地升级
 
 目前支持原地升级的 Workload：
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 目前 `CloneSet`、`Advanced StatefulSet`、`Advanced DaemonSet` 是复用的同一个代码包 [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) 并且有类似的原地升级行为。在本文中，我们会介绍它的用法和工作流程。
 
@@ -89,7 +89,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-当你同时原地升级多个具有不同[启动顺序](/docs/user-manuals/containerlaunchpriority)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
+当你同时原地升级多个具有不同[启动顺序](../user-manuals/containerlaunchpriority.md)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
 
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。
 - 对于存在容器启动顺序的 Pod：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ title: 原地升级
 
 目前支持原地升级的 Workload：
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 目前 `CloneSet`、`Advanced StatefulSet`、`Advanced DaemonSet` 是复用的同一个代码包 [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) 并且有类似的原地升级行为。在本文中，我们会介绍它的用法和工作流程。
 
@@ -89,7 +89,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-当你同时原地升级多个具有不同[启动顺序](/docs/user-manuals/containerlaunchpriority)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
+当你同时原地升级多个具有不同[启动顺序](../user-manuals/containerlaunchpriority.md)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
 
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。
 - 对于存在容器启动顺序的 Pod：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ title: 原地升级
 
 目前支持原地升级的 Workload：
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 目前 `CloneSet`、`Advanced StatefulSet`、`Advanced DaemonSet` 是复用的同一个代码包 [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) 并且有类似的原地升级行为。在本文中，我们会介绍它的用法和工作流程。
 
@@ -89,7 +89,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-当你同时原地升级多个具有不同[启动顺序](/docs/user-manuals/containerlaunchpriority)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
+当你同时原地升级多个具有不同[启动顺序](../user-manuals/containerlaunchpriority.md)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
 
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。
 - 对于存在容器启动顺序的 Pod：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/introduction.md
@@ -56,5 +56,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/user-manuals/sidecarset.md
@@ -313,8 +313,8 @@ spec:
 
 **注意：**
 - k8s 1.28 feature-gate SidecarContainers 默认是关闭的需要主动打开，k8s 1.29 是默认开启的。
-- 如果 K8S 版本`<1.28`，你可以使用 Kruise 提供的 [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-和 [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) 来解决上述问题。
+- 如果 K8S 版本`<1.28`，你可以使用 Kruise 提供的 [Job Sidecar Terminator](./jobsidecarterminator.md)
+和 [Container Launch Priority](./containerlaunchpriority.md) 来解决上述问题。
 
 **此外，当前版本只支持 Sidecar Containers 自动注入，暂时还不支持原地升级能力。**
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ title: 原地升级
 
 目前支持原地升级的 Workload：
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 目前 `CloneSet`、`Advanced StatefulSet`、`Advanced DaemonSet` 是复用的同一个代码包 [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) 并且有类似的原地升级行为。在本文中，我们会介绍它的用法和工作流程。
 
@@ -90,7 +90,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-当你同时原地升级多个具有不同[启动顺序](/docs/user-manuals/containerlaunchpriority)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
+当你同时原地升级多个具有不同[启动顺序](../user-manuals/containerlaunchpriority.md)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
 
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。
 - 对于存在容器启动顺序的 Pod：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/introduction.md
@@ -56,5 +56,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/user-manuals/sidecarset.md
@@ -339,8 +339,8 @@ spec:
 
 **注意：**
 - k8s 1.28 feature-gate SidecarContainers 默认是关闭的需要主动打开，k8s 1.29 是默认开启的。
-- 如果 K8S 版本\<1.28，你可以使用 Kruise 提供的 [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-和 [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) 来解决上述问题。
+- 如果 K8S 版本\<1.28，你可以使用 Kruise 提供的 [Job Sidecar Terminator](./jobsidecarterminator.md)
+和 [Container Launch Priority](./containerlaunchpriority.md) 来解决上述问题。
 
 **此外，当前版本只支持 Sidecar Containers 自动注入，暂时还不支持原地升级能力。**
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/core-concepts/inplace-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ title: 原地升级
 
 目前支持原地升级的 Workload：
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 目前 `CloneSet`、`Advanced StatefulSet`、`Advanced DaemonSet` 是复用的同一个代码包 [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) 并且有类似的原地升级行为。在本文中，我们会介绍它的用法和工作流程。
 
@@ -90,7 +90,7 @@ spec:
 
 **FEATURE STATE:** Kruise v1.1.0
 
-当你同时原地升级多个具有不同[启动顺序](/docs/user-manuals/containerlaunchpriority)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
+当你同时原地升级多个具有不同[启动顺序](../user-manuals/containerlaunchpriority.md)的容器时，Kruise 会按照相同的权重顺序来逐个升级这些容器。
 
 - 对于不存在容器启动顺序的 Pod，在多容器原地升级时没有顺序保证。
 - 对于存在容器启动顺序的 Pod：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/introduction.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/introduction.md
@@ -56,5 +56,5 @@ PaaS 平台可以通过使用 OpenKruise 提供的这些扩展功能，来使得
 
 接下来，我们推荐你：
 
-- 开始 [安装使用 OpenKruise](./docs/installation).
-- 了解 OpenKruise 的 [系统架构](./docs/core-concepts/architecture).
+- 开始 [安装使用 OpenKruise](./installation.md).
+- 了解 OpenKruise 的 [系统架构](./core-concepts/architecture.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/user-manuals/sidecarset.md
@@ -694,8 +694,8 @@ spec:
 
 **注意：**
 - k8s 1.28 feature-gate SidecarContainers 默认是关闭的需要主动打开，k8s 1.29 是默认开启的。
-- 如果 K8S 版本\<1.28，你可以使用 Kruise 提供的 [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-和 [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) 来解决上述问题。
+- 如果 K8S 版本\<1.28，你可以使用 Kruise 提供的 [Job Sidecar Terminator](./jobsidecarterminator.md)
+和 [Container Launch Priority](./containerlaunchpriority.md) 来解决上述问题。
 
 **此外，当前版本只支持 Sidecar Containers 自动注入，暂时还不支持原地升级能力。**
 

--- a/versioned_docs/version-v1.5/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.5/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ In-place Update is one of the key features provided by OpenKruise.
 
 Workloads that support in-place update:
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 Currently `CloneSet`, `Advanced StatefulSet` and `Advanced DaemonSet` reuse the same code package [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) and have similar behaviors of in-place update. In this article, we would like to introduce the usage and workflow of them.
 
@@ -89,7 +89,7 @@ You can see the whole workflow of in-place update below (*you may need to right 
 
 **FEATURE STATE:** Kruise v1.1.0
 
-When you in-place update multiple containers at once and the containers have different [launch priorities](/docs/user-manuals/containerlaunchpriority),
+When you in-place update multiple containers at once and the containers have different [launch priorities](../user-manuals/containerlaunchpriority.md),
 Kruise will update the containers by order according to the priorities.
 
 - For pods without container launch priorities, no guarantees of the execution order during in-place update multiple containers.

--- a/versioned_docs/version-v1.5/user-manuals/resourcedistribution.md
+++ b/versioned_docs/version-v1.5/user-manuals/resourcedistribution.md
@@ -233,4 +233,4 @@ In particular, we **DO NOT** recommend that users bypass the ResourceDistributio
 
 ## Kustomize ResourceDistribution Generator
 
-ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](/docs/next/cli-tool/kustomize-plugin) for details.
+ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](../cli-tool/kustomize-plugin.md) for details.

--- a/versioned_docs/version-v1.6/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.6/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ In-place Update is one of the key features provided by OpenKruise.
 
 Workloads that support in-place update:
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 Currently `CloneSet`, `Advanced StatefulSet` and `Advanced DaemonSet` reuse the same code package [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) and have similar behaviors of in-place update. In this article, we would like to introduce the usage and workflow of them.
 
@@ -89,7 +89,7 @@ You can see the whole workflow of in-place update below (*you may need to right 
 
 **FEATURE STATE:** Kruise v1.1.0
 
-When you in-place update multiple containers at once and the containers have different [launch priorities](/docs/user-manuals/containerlaunchpriority),
+When you in-place update multiple containers at once and the containers have different [launch priorities](../user-manuals/containerlaunchpriority.md),
 Kruise will update the containers by order according to the priorities.
 
 - For pods without container launch priorities, no guarantees of the execution order during in-place update multiple containers.

--- a/versioned_docs/version-v1.6/user-manuals/resourcedistribution.md
+++ b/versioned_docs/version-v1.6/user-manuals/resourcedistribution.md
@@ -233,4 +233,4 @@ In particular, we **DO NOT** recommend that users bypass the ResourceDistributio
 
 ## Kustomize ResourceDistribution Generator
 
-ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](/docs/next/cli-tool/kustomize-plugin) for details.
+ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](../cli-tool/kustomize-plugin.md) for details.

--- a/versioned_docs/version-v1.7/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.7/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ In-place Update is one of the key features provided by OpenKruise.
 
 Workloads that support in-place update:
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 Currently `CloneSet`, `Advanced StatefulSet` and `Advanced DaemonSet` reuse the same code package [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) and have similar behaviors of in-place update. In this article, we would like to introduce the usage and workflow of them.
 
@@ -89,7 +89,7 @@ You can see the whole workflow of in-place update below (*you may need to right 
 
 **FEATURE STATE:** Kruise v1.1.0
 
-When you in-place update multiple containers at once and the containers have different [launch priorities](/docs/user-manuals/containerlaunchpriority),
+When you in-place update multiple containers at once and the containers have different [launch priorities](../user-manuals/containerlaunchpriority.md),
 Kruise will update the containers by order according to the priorities.
 
 - For pods without container launch priorities, no guarantees of the execution order during in-place update multiple containers.

--- a/versioned_docs/version-v1.7/introduction.md
+++ b/versioned_docs/version-v1.7/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/versioned_docs/version-v1.7/user-manuals/resourcedistribution.md
+++ b/versioned_docs/version-v1.7/user-manuals/resourcedistribution.md
@@ -233,4 +233,4 @@ In particular, we **DO NOT** recommend that users bypass the ResourceDistributio
 
 ## Kustomize ResourceDistribution Generator
 
-ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](/docs/next/cli-tool/kustomize-plugin) for details.
+ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](../cli-tool/kustomize-plugin.md) for details.

--- a/versioned_docs/version-v1.7/user-manuals/sidecarset.md
+++ b/versioned_docs/version-v1.7/user-manuals/sidecarset.md
@@ -328,8 +328,8 @@ spec:
 
 **Note:**
 - k8s 1.28 feature-gate SidecarContainers is off by default and needs to be actively turned on, k8s 1.29 is on by default.
-- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-and [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) to solve the above problem.
+- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](./jobsidecarterminator.md)
+and [Container Launch Priority](./containerlaunchpriority.md) to solve the above problem.
 
 **Additionally, the current version only supports automatic injection of Sidecar Containers, and does not yet support in-place update capability.**
 

--- a/versioned_docs/version-v1.8/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.8/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ In-place Update is one of the key features provided by OpenKruise.
 
 Workloads that support in-place update:
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 Currently `CloneSet`, `Advanced StatefulSet` and `Advanced DaemonSet` reuse the same code package [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) and have similar behaviors of in-place update. In this article, we would like to introduce the usage and workflow of them.
 
@@ -90,7 +90,7 @@ You can see the whole workflow of in-place update below (*you may need to right 
 
 **FEATURE STATE:** Kruise v1.1.0
 
-When you in-place update multiple containers at once and the containers have different [launch priorities](/docs/user-manuals/containerlaunchpriority),
+When you in-place update multiple containers at once and the containers have different [launch priorities](../user-manuals/containerlaunchpriority.md),
 Kruise will update the containers by order according to the priorities.
 
 - For pods without container launch priorities, no guarantees of the execution order during in-place update multiple containers.

--- a/versioned_docs/version-v1.8/introduction.md
+++ b/versioned_docs/version-v1.8/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/versioned_docs/version-v1.8/user-manuals/resourcedistribution.md
+++ b/versioned_docs/version-v1.8/user-manuals/resourcedistribution.md
@@ -233,4 +233,4 @@ In particular, we **DO NOT** recommend that users bypass the ResourceDistributio
 
 ## Kustomize ResourceDistribution Generator
 
-ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](/docs/next/cli-tool/kustomize-plugin) for details.
+ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](../cli-tool/kustomize-plugin.md) for details.

--- a/versioned_docs/version-v1.8/user-manuals/sidecarset.md
+++ b/versioned_docs/version-v1.8/user-manuals/sidecarset.md
@@ -356,8 +356,8 @@ spec:
 
 **Note:**
 - k8s 1.28 feature-gate SidecarContainers is off by default and needs to be actively turned on, k8s 1.29 is on by default.
-- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-and [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) to solve the above problem.
+- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](./jobsidecarterminator.md)
+and [Container Launch Priority](./containerlaunchpriority.md) to solve the above problem.
 
 **Additionally, the current version only supports automatic injection of Sidecar Containers, and does not yet support in-place update capability.**
 

--- a/versioned_docs/version-v1.9/core-concepts/inplace-update.md
+++ b/versioned_docs/version-v1.9/core-concepts/inplace-update.md
@@ -6,10 +6,10 @@ In-place Update is one of the key features provided by OpenKruise.
 
 Workloads that support in-place update:
 
-- [CloneSet](/docs/user-manuals/cloneset)
-- [Advanced StatefulSet](/docs/user-manuals/advancedstatefulset)
-- [Advanced DaemonSet](/docs/user-manuals/advanceddaemonset)
-- [SidecarSet](/docs/user-manuals/sidecarset)
+- [CloneSet](../user-manuals/cloneset.md)
+- [Advanced StatefulSet](../user-manuals/advancedstatefulset.md)
+- [Advanced DaemonSet](../user-manuals/advanceddaemonset.md)
+- [SidecarSet](../user-manuals/sidecarset.md)
 
 Currently `CloneSet`, `Advanced StatefulSet` and `Advanced DaemonSet` re-use the same code package [`./pkg/util/inplaceupdate`](https://github.com/openkruise/kruise/tree/master/pkg/util/inplaceupdate) and have similar behaviours of in-place update. In this article, we would like to introduce the usage and workflow of them.
 
@@ -90,7 +90,7 @@ You can see the whole workflow of in-place update below (*you may need to right 
 
 **FEATURE STATE:** Kruise v1.1.0
 
-When you in-place update multiple containers at once and the containers have different [launch priorities](/docs/user-manuals/containerlaunchpriority),
+When you in-place update multiple containers at once and the containers have different [launch priorities](../user-manuals/containerlaunchpriority.md),
 Kruise will update the containers by order according to the priorities.
 
 - For pods without container launch priorities, no guarantees of the execution order during in-place update multiple containers.

--- a/versioned_docs/version-v1.9/introduction.md
+++ b/versioned_docs/version-v1.9/introduction.md
@@ -56,5 +56,5 @@ PaaS can use the features provided by OpenKruise to make applications deployment
 
 Here are some recommended next steps:
 
-- Start to [install OpenKruise](./docs/installation).
-- Learn OpenKruise's [Architecture](./docs/core-concepts/architecture).
+- Start to [install OpenKruise](./installation.md).
+- Learn OpenKruise's [Architecture](./core-concepts/architecture.md).

--- a/versioned_docs/version-v1.9/user-manuals/resourcedistribution.md
+++ b/versioned_docs/version-v1.9/user-manuals/resourcedistribution.md
@@ -233,4 +233,4 @@ In particular, we **DO NOT** recommend that users bypass the ResourceDistributio
 
 ## Kustomize ResourceDistribution Generator
 
-ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](/docs/next/cli-tool/kustomize-plugin) for details.
+ResourceDistribution Generator is a third-party plug-in of kustomize, similar to kustomize's configmap generator and secret generator. Using this plug-in, you can complete the work of reading files as data content to create ResourceDistribution. Refer to [this page](../cli-tool/kustomize-plugin.md) for details.

--- a/versioned_docs/version-v1.9/user-manuals/sidecarset.md
+++ b/versioned_docs/version-v1.9/user-manuals/sidecarset.md
@@ -436,7 +436,7 @@ spec:
 
 SidecarSet supports configuring sidecar container resources based on pod specifications during pod creation.
 
-For design documentation, please refer to: [proposals sidecarset dynamic resources when pod creating](https://github.com/openkruise/kruise/blob/master/docs/proposals/20250913-sidecarset-dynamic-resources-when-creating.md). Best practice: [Dynamic Resource Injection with SidecarSet](docs/best-practices/resource-policy-sidecarset.md)
+For design documentation, please refer to: [proposals sidecarset dynamic resources when pod creating](https://github.com/openkruise/kruise/blob/master/docs/proposals/20250913-sidecarset-dynamic-resources-when-creating.md). Best practice: [Dynamic Resource Injection with SidecarSet](../best-practices/resource-policy-sidecarset.md)
 
 ```yaml
 apiVersion: apps.kruise.io/v1beta1
@@ -703,8 +703,8 @@ spec:
 
 **Note:**
 - k8s 1.28 feature-gate SidecarContainers is off by default and needs to be actively turned on, k8s 1.29 is on by default.
-- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](/docs/user-manuals/jobsidecarterminator)
-and [Container Launch Priority](/docs/user-manuals/containerlaunchpriority) to solve the above problem.
+- If your kubernetes version < 1.28, you can use kruise [Job Sidecar Terminator](./jobsidecarterminator.md)
+and [Container Launch Priority](./containerlaunchpriority.md) to solve the above problem.
 
 **Additionally, the current version only supports automatic injection of Sidecar Containers, and does not yet support in-place update capability.**
 


### PR DESCRIPTION
### Description

While reading through the documentation directly on GitHub, I noticed that several links throughout the repository were using absolute routing paths (like /docs/user-manuals/cloneset) or were missing their .md extensions.

While these links work perfectly fine on the compiled openkruise.io website, they were completely broken and resulting in 404 errors for anyone trying to navigate between the markdown files directly on GitHub.

To make the docs more user-friendly for GitHub readers, I did a sweep across the project and updated these links to use proper relative markdown paths (e.g., ../user-manuals/cloneset.md).

### What this PR does

- Updates absolute /docs/... paths to relative file paths across core-concepts and user-manuals.
- Adds missing .md extensions to ensure GitHub's markdown viewer can correctly navigate between files.
- Updates links in the Chinese release blogs to point to the live website so they don't 404 on GitHub.
- Applies these fixes consistently across all versioned_docs/ and i18n/ translations.