### PR TITLE
fix: Correct version routing logic in version_struct_check.py

### DIFF
--- a/.github/workflows/version_struct_check.py
+++ b/.github/workflows/version_struct_check.py
@@ -140,10 +140,13 @@ def handle() -> None:
         write_info(files)
         if version and version != 'master':
             print(version)
+            # use exact major.minor matching instead of startswith
+            # startswith('0.1') incorrectly matches 0.10.x, 0.11.x etc.
             less_0_5 = False
-            for item in ['0.1', '0.2', '0.3', '0.4']:
-                if version.startswith(item):
-                    less_0_5 = True
+            version_parts = version.split('.')
+            if len(version_parts) >= 2:
+                major_minor = f"{version_parts[0]}.{version_parts[1]}"
+                less_0_5 = major_minor in ['0.1', '0.2', '0.3', '0.4']
             if less_0_5:
                 _download_version(rollouts_format, "v" + version)
                 _exec('cd ./rollouts && go run . ' + tmp_file_path)


### PR DESCRIPTION
## Description
 
Fix a potential version routing bug in `version_struct_check.py` where `startswith()` string matching incorrectly identifies rollouts versions `0.10.x` and above as pre-`0.5` releases, silently routing them to the wrong format validation logic.
 
## Problem Solved
 
`version.startswith('0.1')` matches both intended and unintended versions:
 
| Version | Expected | Actual |
|---------|----------|--------|
| `0.1.5` | `less_0_5 = True`  | `less_0_5 = True`  |
| `0.4.9` | `less_0_5 = True`  | `less_0_5 = True` |
| `0.10.0` | `less_0_5 = False`  | `less_0_5 = True`  |
| `0.11.2` | `less_0_5 = False` | `less_0_5 = True`  |
 
When rollouts releases `v0.10.x`, this bug would silently route it to `rollouts_format` instead of `rollouts_0_5_format`, causing incorrect version validation with zero error output.

#### Fixes : #364 
 
## What's Changed
 
Replaced `startswith()` string matching with explicit `major.minor` parsing:
 
**Before:**
```python
less_0_5 = False
for item in ['0.1', '0.2', '0.3', '0.4']:
    if version.startswith(item):
        less_0_5 = True
```
 
**After:**
```python
less_0_5 = False
version_parts = version.split('.')
if len(version_parts) >= 2:
    major_minor = f"{version_parts[0]}.{version_parts[1]}"
    less_0_5 = major_minor in ['0.1', '0.2', '0.3', '0.4']
```
 
## Files Modified
 
- `.github/workflows/version_struct_check.py` — `handle()` function