### PR TITLE
docs: add v1.9.0 release documentation and blog post

### DIFF
--- a/blog/2026-06-21-release-1.9.md
+++ b/blog/2026-06-21-release-1.9.md
@@ -1,0 +1,281 @@
+---
+slug: openkruise-1.9
+title: OpenKruise V1.9 Release, API v1beta1, Windows Support, and More
+authors: [zmberg]
+tags: [release]
+---
+
+OpenKruise (https://github.com/openkruise/kruise) is an open-source cloud-native application automation management suite. It is also a current incubating project hosted by the Cloud Native Computing Foundation (CNCF). It is a standard extension component based on Kubernetes that is widely used in production of internet scale company. It also closely follows upstream community standards and adapts to the technical improvement and best practices for internet-scale scenarios.
+
+OpenKruise has released the latest version v1.9.0 on June 21, 2026 ([ChangeLog](https://github.com/openkruise/kruise/blob/master/CHANGELOG.md)). This release brings API upgrades to v1beta1, Windows node support, and several new features. This article introduces the key features in detail and briefly covers other notable changes.
+
+## Upgrade Notice
+
+- **Kubernetes dependency** has been updated to v1.32.6 and Golang to v1.23. Make sure your cluster is compatible.
+- **API v1alpha1 → v1beta1**: BroadcastJob, AdvancedCronJob, ImagePullJob, ImageListPullJob, NodeImage, Advanced DaemonSet, and SidecarSet APIs have been upgraded from v1alpha1 to v1beta1. The v1alpha1 APIs are still supported but deprecated, and conversion webhooks handle automatic migration transparently. Users are strongly encouraged to update their manifests to v1beta1 before upgrading to OpenKruise v2.0.
+
+In addition to the apiVersion change, several fields were updated during the promotion:
+
+**SidecarSet** field changes:
+- `spec.namespace` is deprecated — use `spec.namespaceSelector` with the `kubernetes.io/metadata.name` label instead.
+- The `"apps.kruise.io/sidecarset-custom-version"` annotation is replaced by the `spec.customVersion` field.
+
+```yaml
+# Before (v1alpha1)
+apiVersion: apps.kruise.io/v1alpha1
+kind: SidecarSet
+metadata:
+  annotations:
+    apps.kruise.io/sidecarset-custom-version: "v1"
+spec:
+  namespace: default
+```
+
+```yaml
+# After (v1beta1)
+apiVersion: apps.kruise.io/v1beta1
+kind: SidecarSet
+metadata:
+  name: my-sidecarset
+spec:
+  customVersion: v1
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+```
+
+**Advanced DaemonSet** field changes:
+- The `"daemonset.kruise.io/progressive-create-pod"` annotation is replaced by `spec.scaleStrategy`.
+- `status.DaemonSetHash` is replaced by `status.UpdateRevision`.
+- `spec.partition` type changed from `*int32` to `*intstr.IntOrString` — now supports percentage values like `50%`.
+- `spec.updateStrategy.rollingUpdate.type: Surging` is deprecated — use `Standard` instead.
+
+```yaml
+# After (v1beta1) — partition now supports percentage
+apiVersion: apps.kruise.io/v1beta1
+kind: AdvancedDaemonSet
+spec:
+  partition: "50%"
+  updateStrategy:
+    rollingUpdate:
+      type: Standard
+```
+
+For the full list of API promotions and field changes, see the [API Upgrade Guide](https://openkruise.io/docs/operator-manuals/upgrade#api-update-detail).
+
+**Note**: The `v1alpha1` API for Advanced StatefulSet will be removed in OpenKruise v2.0. Other `v1alpha1` APIs have no removal plan yet, but migration is recommended to avoid conversion webhook overhead.
+
+## Key Features
+
+### UnitedDeployment ReserveUnschedulablePods
+
+In elastic scenarios, you often want to prioritize scheduling Pods on owned node pools (e.g., self-built IDC) and use elastic node pools (e.g., virtual-kubelet) as fallback. The existing Adaptive strategy permanently moves Pods to other subsets when the target subset is unschedulable. However, this means you lose the preferred topology — even after the original subset recovers, the Pods stay where they were moved.
+
+v1.9.0 introduces `reserveUnschedulablePods` under the Adaptive scheduling strategy. When enabled, unschedulable Pods are **reserved** in the target subset, and a temporary replica is created in the next available subset to maintain the expected replica count. Once the target subset becomes schedulable again, the temporary replica is deleted and the reserved Pod is scheduled back to the original subset.
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: sample-ud
+spec:
+  topology:
+    scheduleStrategy:
+      type: Adaptive
+      adaptive:
+        reserveUnschedulablePods: true
+        rescheduleCriticalSeconds: 30
+    subsets:
+      - name: ecs
+        nodeSelectorTerm:
+          matchExpressions:
+            - key: node-type
+              operator: In
+              values: [ecs]
+      - name: vk
+        nodeSelectorTerm:
+          matchExpressions:
+            - key: node-type
+              operator: In
+              values: [virtual-kubelet]
+```
+
+In this example, Pods are prioritized on ECS nodes. When ECS nodes are full, temporary replicas are created on virtual-kubelet nodes. Once ECS capacity is restored (e.g., after node scaling), the temporary replicas are removed and Pods migrate back to ECS.
+
+**Limitation**: Only works with the `Adaptive` scheduling strategy. The temporary replica creation is recursive across subsets.
+
+### AdvancedCronJob Cron ImagePullJob
+
+For AI/ML workloads that use large images (e.g., several GB), pre-pulling images before Pod scheduling significantly reduces startup time. In large model workload clusters, nodes frequently garbage-collect (GC) images due to disk space pressure, so pre-warming needs to be re-run before scheduled tasks to ensure effectiveness. Previously, you had to manually create ImagePullJob resources or use external cron tools. Now you can schedule image pre-pulling as a cron task directly within AdvancedCronJob using the new `imageListPullJobTemplate` field.
+
+```yaml
+apiVersion: apps.kruise.io/v1beta1
+kind: AdvancedCronJob
+metadata:
+  name: acj-image-pull
+spec:
+  schedule: "0 */2 * * *"
+  concurrencyPolicy: Replace
+  template:
+    imageListPullJobTemplate:
+      spec:
+        parallelism: 5
+        images:
+        - nginx:1.14.2
+        - busybox:latest
+        pullSecrets:
+        - default-secret
+        selector:
+          names:
+          - node1
+          - node2
+        pullPolicy:
+          timeoutSeconds: 60
+        imagePullPolicy: IfNotPresent
+```
+
+This example creates an ImageListPullJob every 2 hours, pulling the specified images on node1 and node2. The `concurrencyPolicy: Replace` ensures that if a new job is triggered while the previous one is still running, the old one is replaced.
+
+**Limitation**: Uses the v1beta1 API. The `imageListPullJobTemplate` field is available since v1.9.0.
+
+### CloneSet progressDeadlineSeconds
+
+In CI/CD pipelines, it is important to detect rollout failures early. Without a progress deadline, a stuck rollout (e.g., image pull errors, readiness probe failures) can hang indefinitely without any signal. v1.9.0 adds `progressDeadlineSeconds` to CloneSet, similar to the native Kubernetes Deployment field.
+
+```yaml
+apiVersion: apps.kruise.io/v1beta1
+kind: CloneSet
+spec:
+  replicas: 10
+  progressDeadlineSeconds: 600
+  # ...
+```
+
+If the rollout does not progress within 600 seconds, the CloneSet controller adds the following condition to `.status.conditions`:
+
+```yaml
+type: Progressing
+status: "False"
+reason: ProgressDeadlineExceeded
+```
+
+Higher-level orchestration systems (e.g., ArgoCD, Flux) can watch this condition to trigger automatic rollbacks.
+
+**Limitation**: The value must be greater than `spec.minReadySeconds`. This condition does **not** stop the underlying rollout — it only signals the failure. Pausing the rollout also pauses the deadline check.
+
+### SidecarSet Dynamic Resources
+
+Sidecar containers (e.g., service mesh proxies, log agents) often need resources proportional to the main container. Previously, you had to set fixed resource requests/limits for sidecars, which led to either over-provisioning for small Pods or under-provisioning for large Pods.
+
+v1.9.0 introduces `resourcesPolicy`, which lets you define sidecar resources as **expressions** based on the target Pod's container resources.
+
+```yaml
+apiVersion: apps.kruise.io/v1beta1
+kind: SidecarSet
+spec:
+  containers:
+  - name: sidecar1
+    image: centos:6.7
+    resourcesPolicy:
+      targetContainersMode: sum
+      targetContainersNameRegex: ^large-engine-v4$
+      resourcesExpr:
+        limits:
+          cpu: max(cpu*50%, 50m)
+          memory: 200Mi
+        requests:
+          cpu: max(cpu*50%, 50m)
+          memory: 100Mi
+```
+
+In this example, the sidecar's CPU is set to 50% of the `large-engine-v4` container's CPU, with a minimum of 50m. Supported expression operators include `+`, `-`, `*`, `/`, `max()`, `min()`, and Kubernetes resource quantities (e.g., `50m`, `200Mi`).
+
+**Limitation**: The `cpu` and `memory` variables in the expression represent the aggregated resource values from target containers, calculated based on `targetContainersMode` (e.g., `sum`) and `targetContainersNameRegex`.
+
+### PodUnavailableBudget RESIZE Protection
+
+PodUnavailableBudget (PUB) protects application availability by limiting how many Pods can be unavailable simultaneously. Previously, PUB protected against `DELETE`, `EVICT`, and `UPDATE` operations. With the growing adoption of in-place vertical scaling (Kubernetes 1.27+ `InPlacePodVerticalScaling`), `RESIZE` operations can also make Pods temporarily unavailable.
+
+v1.9.0 adds `RESIZE` as a protected operation. You can control which operations are protected via an annotation:
+
+```yaml
+apiVersion: policy.kruise.io/v1alpha1
+kind: PodUnavailableBudget
+metadata:
+  name: web-server-pub
+  annotations:
+    # By default: DELETE, EVICT, UPDATE are protected
+    # Add RESIZE to also protect in-place resource resizing
+    kruise.io/pub-protect-operations: "DELETE, EVICT, UPDATE, RESIZE"
+spec:
+  targetRef:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: CloneSet
+    name: web-server
+  maxUnavailable: 20%
+```
+
+**Limitation**: If the `InPlacePodVerticalScaling` feature gate is disabled, in-place resizing is treated as an `UPDATE` operation instead.
+
+## Other Notable Changes
+
+The following features were also introduced in v1.9.0 — see the [documentation](https://openkruise.io/docs/) for details:
+
+- **SidecarSet shareVolumeDevicePolicy**: Sidecar containers can now share block devices (VolumeDevices) with other containers in the Pod, analogous to the existing `shareVolumePolicy` for volume mounts.
+- **SidecarSet injection order**: SidecarSet now sorts `containers` and `initContainers` by name in ascending order during injection, ensuring deterministic ordering for sidecars with dependencies.
+- **PodProbeMarker HTTP probe**: Supports `httpGet` probes in addition to `exec` and `tcpSocket`, enabling direct HTTP health checks without wrapping `curl` in exec.
+- **CloneSet OnDelete strategy**: A new `podUpdatePolicy` type where Pods are only updated when manually deleted — useful for stateful workloads requiring manual update control.
+- **JobSidecarTerminator exit code control**: The `KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE` env var lets you explicitly control whether a sidecar's non-zero exit code affects Pod Phase.
+- **ImagePullJob node-side concurrency**: The `--max-concurrency` flag on kruise-daemon limits concurrent image pulls per node, preventing resource exhaustion.
+- **OpenKruise Daemon Windows support**: kruise-daemon now runs on Windows nodes, enabling CRR, image pre-pulling, and PodProbeMarker for Windows workloads.
+
+## Other Improvements
+
+Various bug fixes and stability improvements are included in this release. For the full list, see the [changelog](https://github.com/openkruise/kruise/blob/master/CHANGELOG.md).
+
+## What's Next in v2.0
+
+Looking ahead, the next major release (v2.0) will bring two significant changes:
+
+**More API upgrades to `v1beta1`**: CloneSet, WorkloadSpread, UnitedDeployment, PersistentPodState, PodUnavailableBudget, PodProbeMarker, and NodePodProbe will be promoted from `v1alpha1` to `v1beta1`. Additionally, the `v1alpha1` API for Advanced StatefulSet will be removed in v2.0.
+
+**ConfigMapSet — a new configuration canary release feature**: ConfigMapSet is a new CRD currently under active development on the master branch. It enables zero-downtime configuration updates decoupled from image releases — you can update configuration data (e.g., YAML files, environment variables) and roll it out gradually without rebuilding images. Key capabilities include:
+
+- **Version management**: Maintains a revision history of configuration versions, allowing rollback to previous versions.
+- **Configuration canary**: Uses `partition` in `updateStrategy` to control the rollout percentage, enabling gradual configuration updates.
+- **Container selection**: Supports both static container names and dynamic selection via field references (compatible with SidecarSet injection).
+- **Update strategies**: Two modes — injection-only (default) where the reload sidecar updates configs without restarting containers, and `restartInjectedContainers` mode where containers using the configuration are also restarted.
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: ConfigMapSet
+metadata:
+  name: deploy-cms
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  data:
+    settings.yaml: |
+      value: aaa
+  containers:
+  - name: main
+    mountPath: /data/conf
+  revisionHistoryLimit: 5
+  updateStrategy:
+    partition: 10%
+    restartInjectedContainers: true
+    maxUnavailable: 1
+```
+
+**Note**: ConfigMapSet is still under active development. The API and feature set may change before the official release.
+
+## Get Involved
+
+Welcome to get involved with OpenKruise by joining us in Github/Slack/DingTalk/WeChat.
+Have something you'd like to broadcast to our community?
+Share your voice at our [Bi-weekly community meeting (Chinese)](https://shimo.im/docs/gXqmeQOYBehZ4vqo), or through the channels below:
+
+- Join the community on [Slack](https://kubernetes.slack.com/channels/openkruise) (English).
+- Join the community on DingTalk: Search GroupID `23330762` (Chinese).
+- Join the community on WeChat (new): Search User `openkruise` and let the robot invite you (Chinese).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -215,6 +215,20 @@ $ helm install kruise https://... --set featureGates="ResourcesDeletionProtectio
 
 If you want to enable all feature-gates, set the parameter as `featureGates=AllAlpha=true`.
 
+### Optional: Windows node support
+
+**FEATURE STATE:** Kruise v1.9.0
+
+Since v1.9.0, OpenKruise Daemon supports Windows nodes. This enables features such as ImagePullJob and ContainerRecreateRequest (CRR) to work on Windows nodes.
+
+To deploy kruise-daemon on Windows nodes, make sure your cluster has Windows nodes with container runtime installed, and Kruise will automatically schedule the kruise-daemon DaemonSet to Windows nodes.
+
+You can also customize the kruise-daemon image for Windows nodes using the following Helm parameter:
+
+```bash
+$ helm install kruise https://... --set daemon.windowsImage.repository=openkruise/kruise-daemon-windows --set daemon.windowsImage.tag=v1.9.0
+```
+
 ### Optional: the local image for China
 
 If you are in China and have problem to pull image from official DockerHub, you can use the registry hosted on Alibaba

--- a/docs/user-manuals/cloneset.md
+++ b/docs/user-manuals/cloneset.md
@@ -433,11 +433,12 @@ The effect of the above configuration is that during scaling up, CloneSet will n
 
 ### Update types
 
-CloneSet provides three update types, defaults to `ReCreate`.
+CloneSet provides four update types, defaults to `ReCreate`.
 
 - `ReCreate`: controller will delete old Pods and PVCs and create new ones.
 - `InPlaceIfPossible`: controller will try to in-place update Pod instead of recreating them if possible. Current only image and other fields are supported for in-place update.
 - `InPlaceOnly`: controller will in-place update Pod instead of recreating them. With `InPlaceOnly` policy, user cannot modify any fields other than the fields that supported to in-place update.
+- `OnDelete`: **FEATURE STATE:** Kruise v1.9.0. controller will not automatically update Pods. Pods are only updated when they are manually deleted. Version tracking and ordered rolling restarts are disabled. This is useful when you want to control the update of each Pod manually.
 
 **You may need to read the [concept doc](../core-concepts/inplace-update) for more details of in-place update.**
 

--- a/docs/user-manuals/imagepulljob.md
+++ b/docs/user-manuals/imagepulljob.md
@@ -259,6 +259,14 @@ spec:
 </TabItem>
 </Tabs>
 
+### Node-side concurrency control
+
+**FEATURE STATE:** Kruise v1.9.0
+
+Since v1.9.0, the kruise-daemon supports node-side concurrency control for image pulling. This feature limits the number of concurrent image pulls on each node, preventing resource exhaustion (CPU, memory, disk I/O) when multiple ImagePullJobs target the same node simultaneously.
+
+The concurrency limit can be configured via the `--max-concurrency` flag of kruise-daemon. By default, the daemon uses a worker pool to limit concurrent image pull operations per node.
+
 ## ImageListPullJob
 
 **FEATURE STATE:** Kruise v1.5.0

--- a/docs/user-manuals/jobsidecarterminator.md
+++ b/docs/user-manuals/jobsidecarterminator.md
@@ -69,6 +69,31 @@ If the sidecar container had non-zero exit code, it would result in Pod Phase=Fa
 
 As of Kruise 1.6.0, Kruise will ignore sidecar container with non-zero exit code, and Pod Phase only depend on the success or failure of the main containers.
 
+### Configure exit code ignore behavior via environment variable
+
+**FEATURE STATE:** Kruise v1.9.0
+
+Since v1.9.0, users can explicitly control whether to ignore the sidecar container's non-zero exit code by setting the `KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE` environment variable on the sidecar container.
+
+- If set to `"true"`, the sidecar container's non-zero exit code will be ignored, and Pod Phase will only depend on the main containers (same as the default behavior since v1.6.0).
+- If set to `"false"`, the sidecar container's exit code will affect Pod Phase. A non-zero exit code will result in Pod Phase=Failed.
+
+```yaml
+kind: Job
+spec:
+  template:
+    spec:
+      containers:
+        - name: sidecar
+          env:
+            - name: KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT
+              value: "true"
+            - name: KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE
+              value: "false"
+        - name: main
+... ...
+```
+
 ### Notes
 
 - Your sidecar container must respond the `SIGTERM` signal, and the entrypoint should `exit 0` when received this signal.

--- a/docs/user-manuals/podprobemarker.md
+++ b/docs/user-manuals/podprobemarker.md
@@ -65,7 +65,7 @@ Once specified, selector cannot be changed for a PodProbeMarker.
 - spec.probes
   - **name**: The probe name needs to be unique within the Pod and between different containers
   - **containerName**: The container that executes the probe
-  - **probe**: The API definition related to probe is consistent with the native K8S probe (currently only Exec and tcpSocket is supported). For details, please refer to: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  - **probe**: The API definition related to probe is consistent with the native K8S probe (currently supports Exec, tcpSocket, and HTTP probes). For details, please refer to: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
   - **markerPolicy**: According to the Probe execution result (Succeeded or Failed), patch specific Labels and Annotations to the Pod.
     - state: probe result, Succeeded or Failed
     - labels: If the result is satisfied, patch labels to the Pod
@@ -98,6 +98,33 @@ spec:
     containerName: game-server
     probe:
       tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 10
+```
+
+### Support HTTP Probe
+
+**FEATURE STATE:** Kruise v1.9.0
+
+Since v1.9.0, PodProbeMarker supports HTTP probes. With this configuration, the kruise-daemon will send an HTTP `GET` request to the specified path and port on the container. If the response status code is between 200 and 399 (inclusive), the probe is considered `Succeeded`; otherwise, it is considered `Failed`. For example:
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: PodProbeMarker
+metadata:
+  name: game-server-probe
+  namespace: ns
+spec:
+  selector:
+    matchLabels:
+      app: game-server
+  probes:
+  - name: Idle
+    containerName: game-server
+    probe:
+      httpGet:
+        path: /healthz
         port: 8080
       initialDelaySeconds: 15
       periodSeconds: 10

--- a/docs/user-manuals/sidecarset.md
+++ b/docs/user-manuals/sidecarset.md
@@ -286,6 +286,8 @@ spec:
     podInjectPolicy: BeforeAppContainer
     shareVolumePolicy:
       type: disabled | enabled
+    shareVolumeDevicePolicy:
+      type: disabled | enabled
     transferEnv:
     - sourceContainerName: main
       envName: PROXY_IP
@@ -333,6 +335,8 @@ spec:
     podInjectPolicy: BeforeAppContainer
     shareVolumePolicy:
       type: disabled | enabled
+    shareVolumeDevicePolicy:
+      type: disabled | enabled
     transferEnv:
     - sourceContainerName: main
       envName: PROXY_IP
@@ -355,11 +359,19 @@ spec:
 - data volume sharing
     - Share specific volumes: Use spec.volumes to define the volumes needed by Sidecar itself. See details：https://kubernetes.io/docs/concepts/storage/volumes/
     - Share pod containers volumes: If ShareVolumePolicy.type is enabled, the sidecar container will share the other container's VolumeMounts in the pod(don't contains the injected sidecar container)
+    - Share pod containers volume devices: If ShareVolumeDevicePolicy.type is enabled, the sidecar container will share the other container's VolumeDevices in the pod(don't contains the injected sidecar container). **FEATURE STATE:** Kruise v1.9.0
 - Environment variable sharing
     - Environment variables can be fetched from another container through spec.containers[x].transferenv, and the environment variable named envName from the container named sourceContainerName is copied to this container
     - sourceContainerNameFrom support downwardAPI for container name, such as `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`
 - Injection ResourcesPolicy
     - User can configure the resource expression for sidecar container to dynamically adjust its resources based on the target container's resources by field `.spec.containers[i].resourcesPolicy` and `.spec.initContainers[i].resourcesPolicy`
+
+#### Injection Order of Sidecar Containers
+**FEATURE STATE:** Kruise v1.9.0
+
+Since v1.9.0, SidecarSet sorts both `spec.containers` and `spec.initContainers` by their name in ascending order when injecting them into Pods. This guarantees a deterministic injection order, ensuring that sidecar containers with dependencies on each other are injected in the correct sequence.
+
+For example, if a SidecarSet defines containers named `envoy`, `log-agent`, and `nginx`, they will be injected into the Pod in the order: `envoy`, `log-agent`, `nginx`.
 
 #### injection pause
 **FEATURE STATE:** Kruise v0.10.0

--- a/i18n/zh/docusaurus-plugin-content-blog/2026-06-21-release-1.9.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2026-06-21-release-1.9.md
@@ -1,0 +1,281 @@
+---
+slug: openkruise-1.9
+title: OpenKruise V1.9 版本发布：API v1beta1、Windows 支持及更多新特性
+authors: [zmberg]
+tags: [release]
+---
+
+OpenKruise（ https://github.com/openkruise/kruise ）是阿里云开源的云原生应用自动化管理套件，也是当前托管在 Cloud Native Computing Foundation (CNCF) 下的孵化项目。它来自阿里巴巴多年来容器化、云原生的技术沉淀，是阿里内部生产环境大规模应用的基于 Kubernetes 之上的标准扩展组件，也是紧贴上游社区标准、适应互联网规模化场景的技术理念与最佳实践。
+
+OpenKruise 在 2026.6.21 发布了最新的 v1.9.0 版本（[ChangeLog](https://github.com/openkruise/kruise/blob/master/CHANGELOG.md)），本次发布带来了 API v1beta1 升级、Windows 节点支持，以及多项新特性。本文将详细介绍核心特性，并简要介绍其他重要变更。
+
+## 升级须知
+
+- **Kubernetes 依赖**已更新至 v1.32.6，Golang 更新至 v1.23，请确保集群兼容。
+- **API v1alpha1 → v1beta1**：BroadcastJob、AdvancedCronJob、ImagePullJob、ImageListPullJob、NodeImage、Advanced DaemonSet 和 SidecarSet 的 API 已从 v1alpha1 升级至 v1beta1。v1alpha1 API 仍然支持但已废弃，转换 webhook 会自动处理迁移。强烈建议用户在升级到 OpenKruise v2.0 之前将清单更新为 v1beta1。
+
+除了 apiVersion 变更外，升级过程中还修改了若干字段：
+
+**SidecarSet** 字段变更：
+- `spec.namespace` 已废弃——改用 `spec.namespaceSelector` 配合 `kubernetes.io/metadata.name` 标签。
+- `"apps.kruise.io/sidecarset-custom-version"` 注解被 `spec.customVersion` 字段替代。
+
+```yaml
+# 升级前（v1alpha1）
+apiVersion: apps.kruise.io/v1alpha1
+kind: SidecarSet
+metadata:
+  annotations:
+    apps.kruise.io/sidecarset-custom-version: "v1"
+spec:
+  namespace: default
+```
+
+```yaml
+# 升级后（v1beta1）
+apiVersion: apps.kruise.io/v1beta1
+kind: SidecarSet
+metadata:
+  name: my-sidecarset
+spec:
+  customVersion: v1
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+```
+
+**Advanced DaemonSet** 字段变更：
+- `"daemonset.kruise.io/progressive-create-pod"` 注解被 `spec.scaleStrategy` 替代。
+- `status.DaemonSetHash` 被 `status.UpdateRevision` 替代。
+- `spec.partition` 类型从 `*int32` 变为 `*intstr.IntOrString`——现在支持百分比值，如 `50%`。
+- `spec.updateStrategy.rollingUpdate.type: Surging` 已废弃——请使用 `Standard`。
+
+```yaml
+# 升级后（v1beta1）——partition 支持百分比
+apiVersion: apps.kruise.io/v1beta1
+kind: AdvancedDaemonSet
+spec:
+  partition: "50%"
+  updateStrategy:
+    rollingUpdate:
+      type: Standard
+```
+
+完整的 API 升级和字段变更列表，请参阅 [API 升级指南](https://openkruise.io/docs/operator-manuals/upgrade#api-update-detail)。
+
+**注意**：Advanced StatefulSet 的 `v1alpha1` API 将在 OpenKruise v2.0 中移除。其他 `v1alpha1` API 暂无移除计划，但建议尽早迁移以避免转换 webhook 的性能开销。
+
+## 核心特性
+
+### UnitedDeployment ReserveUnschedulablePods
+
+在弹性场景中，用户通常希望优先将 Pod 调度到自有节点池（如自建 IDC），将弹性节点池（如 virtual-kubelet）作为兜底。现有的 Adaptive 策略在目标 Subset 不可调度时会永久将 Pod 调度到其他 Subset，这意味着即使原 Subset 恢复，Pod 也不会迁移回来。
+
+v1.9.0 引入了 `reserveUnschedulablePods` 选项，在 Adaptive 调度策略下启用后，不可调度的 Pod 会被**保留**在目标 Subset 中，同时在下一个可用 Subset 中创建临时副本以维持期望副本数。当目标 Subset 恢复调度能力后，临时副本将被删除，保留的 Pod 会重新调度回原 Subset。
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: sample-ud
+spec:
+  topology:
+    scheduleStrategy:
+      type: Adaptive
+      adaptive:
+        reserveUnschedulablePods: true
+        rescheduleCriticalSeconds: 30
+    subsets:
+      - name: ecs
+        nodeSelectorTerm:
+          matchExpressions:
+            - key: node-type
+              operator: In
+              values: [ecs]
+      - name: vk
+        nodeSelectorTerm:
+          matchExpressions:
+            - key: node-type
+              operator: In
+              values: [virtual-kubelet]
+```
+
+在这个示例中，Pod 优先调度到 ECS 节点。当 ECS 节点资源不足时，会在 virtual-kubelet 节点上创建临时副本。当 ECS 容量恢复后（例如节点扩容），临时副本被删除，Pod 迁移回 ECS。
+
+**限制**：仅在 `Adaptive` 调度策略下生效。临时副本的创建在 Subset 间递归执行。
+
+### AdvancedCronJob 定时 ImagePullJob
+
+对于 AI/ML 等使用大镜像（数 GB 级别）的工作负载，在 Pod 调度前预拉取镜像可以显著减少启动时间。在大模型负载的集群中，节点经常因磁盘空间压力而 GC 镜像，因此需要在定时任务运行前重新预热，确保预热效果。此前，用户需要手动创建 ImagePullJob 资源或使用外部定时工具。现在可以直接在 AdvancedCronJob 中使用新增的 `imageListPullJobTemplate` 字段，将镜像预拉取作为定时任务调度。
+
+```yaml
+apiVersion: apps.kruise.io/v1beta1
+kind: AdvancedCronJob
+metadata:
+  name: acj-image-pull
+spec:
+  schedule: "0 */2 * * *"
+  concurrencyPolicy: Replace
+  template:
+    imageListPullJobTemplate:
+      spec:
+        parallelism: 5
+        images:
+        - nginx:1.14.2
+        - busybox:latest
+        pullSecrets:
+        - default-secret
+        selector:
+          names:
+          - node1
+          - node2
+        pullPolicy:
+          timeoutSeconds: 60
+        imagePullPolicy: IfNotPresent
+```
+
+这个示例每 2 小时创建一个 ImageListPullJob，在 node1 和 node2 上拉取指定镜像。`concurrencyPolicy: Replace` 确保新任务触发时，仍在运行的旧任务会被替换。
+
+**限制**：使用 v1beta1 API。`imageListPullJobTemplate` 字段自 v1.9.0 起可用。
+
+### CloneSet progressDeadlineSeconds
+
+在 CI/CD 流水线中，尽早检测发布失败非常重要。没有进度截止时间的情况下，卡住的发布（例如镜像拉取错误、就绪探针失败）可能无限期挂起而没有任何信号。v1.9.0 为 CloneSet 新增了 `progressDeadlineSeconds` 字段，类似原生 Kubernetes Deployment。
+
+```yaml
+apiVersion: apps.kruise.io/v1beta1
+kind: CloneSet
+spec:
+  replicas: 10
+  progressDeadlineSeconds: 600
+  # ...
+```
+
+如果发布在 600 秒内未取得进展，CloneSet 控制器会在 `.status.conditions` 中添加以下条件：
+
+```yaml
+type: Progressing
+status: "False"
+reason: ProgressDeadlineExceeded
+```
+
+上层编排系统（如 ArgoCD、Flux）可以监控此条件来触发自动回滚。
+
+**限制**：该值必须大于 `spec.minReadySeconds`。此条件**不会**停止底层发布——它只是发出失败信号。暂停发布也会暂停截止时间检查。
+
+### SidecarSet 动态资源
+
+Sidecar 容器（如服务网格代理、日志 Agent）通常需要与主容器成比例的资源。此前，用户必须为 sidecar 设置固定的资源请求/限制，这导致小 Pod 过度分配或大 Pod 分配不足。
+
+v1.9.0 引入了 `resourcesPolicy`，允许通过**表达式**根据目标 Pod 容器资源来定义 sidecar 资源。
+
+```yaml
+apiVersion: apps.kruise.io/v1beta1
+kind: SidecarSet
+spec:
+  containers:
+  - name: sidecar1
+    image: centos:6.7
+    resourcesPolicy:
+      targetContainersMode: sum
+      targetContainersNameRegex: ^large-engine-v4$
+      resourcesExpr:
+        limits:
+          cpu: max(cpu*50%, 50m)
+          memory: 200Mi
+        requests:
+          cpu: max(cpu*50%, 50m)
+          memory: 100Mi
+```
+
+在这个示例中，sidecar 的 CPU 设置为 `large-engine-v4` 容器 CPU 的 50%，最小为 50m。支持的表达式运算符包括 `+`、`-`、`*`、`/`、`max()`、`min()` 和 Kubernetes 资源量（如 `50m`、`200Mi`）。
+
+**限制**：表达式中的 `cpu` 和 `memory` 变量代表根据 `targetContainersMode`（如 `sum`）和 `targetContainersNameRegex` 计算的目标容器聚合资源值。
+
+### PodUnavailableBudget RESIZE 保护
+
+PodUnavailableBudget (PUB) 通过限制同时不可用的 Pod 数量来保护应用可用性。此前，PUB 保护 `DELETE`、`EVICT` 和 `UPDATE` 操作。随着原地垂直扩缩容（Kubernetes 1.27+ `InPlacePodVerticalScaling`）的普及，`RESIZE` 操作也可能导致 Pod 暂时不可用。
+
+v1.9.0 新增 `RESIZE` 作为受保护的操作。可以通过注解控制受保护的操作类型：
+
+```yaml
+apiVersion: policy.kruise.io/v1alpha1
+kind: PodUnavailableBudget
+metadata:
+  name: web-server-pub
+  annotations:
+    # 默认保护: DELETE, EVICT, UPDATE
+    # 添加 RESIZE 以保护原地资源调整
+    kruise.io/pub-protect-operations: "DELETE, EVICT, UPDATE, RESIZE"
+spec:
+  targetRef:
+    apiVersion: apps.kruise.io/v1beta1
+    kind: CloneSet
+    name: web-server
+  maxUnavailable: 20%
+```
+
+**限制**：如果 `InPlacePodVerticalScaling` feature gate 未启用，原地资源调整将被视为 `UPDATE` 操作。
+
+## 其他重要变更
+
+以下特性也在 v1.9.0 中引入——详情请参阅[文档](https://openkruise.io/docs/)：
+
+- **SidecarSet shareVolumeDevicePolicy**：Sidecar 容器现在可以与 Pod 中其他容器共享块设备（VolumeDevices），类似于现有的用于卷挂载的 `shareVolumePolicy`。
+- **SidecarSet 注入顺序**：SidecarSet 在注入时按名称升序对 `containers` 和 `initContainers` 排序，确保有依赖关系的 sidecar 容器按正确顺序注入。
+- **PodProbeMarker HTTP 探针**：除 `exec` 和 `tcpSocket` 外，支持 `httpGet` 探针，无需通过 exec 包装 `curl` 即可直接进行 HTTP 健康检查。
+- **CloneSet OnDelete 策略**：新增 `podUpdatePolicy` 类型，仅在 Pod 被手动删除时才更新——适用于需要手动控制更新的有状态工作负载。
+- **JobSidecarTerminator 退出码控制**：`KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE` 环境变量允许显式控制 sidecar 的非零退出码是否影响 Pod Phase。
+- **ImagePullJob 节点侧并发控制**：kruise-daemon 的 `--max-concurrency` 标志限制每个节点的并发镜像拉取数量，防止资源耗尽。
+- **OpenKruise Daemon Windows 支持**：kruise-daemon 现在支持 Windows 节点，使 CRR、镜像预拉取和 PodProbeMarker 可用于 Windows 工作负载。
+
+## 其他改进
+
+本版本包含多项 Bug 修复和稳定性改进。完整列表请参阅 [changelog](https://github.com/openkruise/kruise/blob/master/CHANGELOG.md)。
+
+## 展望 v2.0
+
+展望未来，下一个大版本（v2.0）将带来两项重要变更：
+
+**更多 API 升级到 `v1beta1`**：CloneSet、WorkloadSpread、UnitedDeployment、PersistentPodState、PodUnavailableBudget、PodProbeMarker 和 NodePodProbe 将从 `v1alpha1` 升级到 `v1beta1`。此外，Advanced StatefulSet 的 `v1alpha1` API 将在 v2.0 中移除。
+
+**ConfigMapSet——全新的配置灰度发布功能**：ConfigMapSet 是目前正在 master 分支上积极开发的新 CRD。它支持与镜像发布解耦的零停机配置更新——可以更新配置数据（如 YAML 文件、环境变量）并逐步灰度发布，无需重新构建镜像。核心能力包括：
+
+- **版本管理**：维护配置版本的修订历史，支持回滚到之前的版本。
+- **配置灰度**：通过 `updateStrategy` 中的 `partition` 控制灰度比例，实现配置的渐进式更新。
+- **容器选择**：支持静态容器名称和通过字段引用的动态选择（兼容 SidecarSet 注入）。
+- **更新策略**：两种模式——仅注入（默认）模式下 reload sidecar 更新配置但不重启容器；`restartInjectedContainers` 模式下使用配置的容器也会被重启。
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: ConfigMapSet
+metadata:
+  name: deploy-cms
+spec:
+  selector:
+    matchLabels:
+      app: sample
+  data:
+    settings.yaml: |
+      value: aaa
+  containers:
+  - name: main
+    mountPath: /data/conf
+  revisionHistoryLimit: 5
+  updateStrategy:
+    partition: 10%
+    restartInjectedContainers: true
+    maxUnavailable: 1
+```
+
+**注意**：ConfigMapSet 仍在积极开发中。API 和功能集在正式发布前可能会有变化。
+
+## 参与社区
+
+欢迎通过 Github/Slack/DingTalk/WeChat 参与 OpenKruise 社区。
+有什么想向社区广播的内容吗？
+在我们的[双周社区会议（中文）](https://shimo.im/docs/gXqmeQOYBehZ4vqo)上分享您的声音，或通过以下渠道：
+
+- 在 [Slack](https://kubernetes.slack.com/channels/openkruise) 上加入社区（英文）。
+- 在钉钉上加入社区：搜索群号 `23330762`（中文）。
+- 在微信上加入社区（新）：搜索用户 `openkruise` 并让机器人邀请您（中文）。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation.md
@@ -199,6 +199,20 @@ $ helm install kruise https://... --set featureGates="ResourcesDeletionProtectio
 
 如果你希望打开所有 feature-gate 功能，配置参数 `featureGates=AllAlpha=true`。
 
+### 可选: Windows 节点支持
+
+**FEATURE STATE:** Kruise v1.9.0
+
+从 v1.9.0 开始，OpenKruise Daemon 支持 Windows 节点。这使得 ImagePullJob 和 ContainerRecreateRequest (CRR) 等功能可以在 Windows 节点上运行。
+
+要在 Windows 节点上部署 kruise-daemon，请确保集群中已安装容器运行时的 Windows 节点，Kruise 会自动将 kruise-daemon DaemonSet 调度到 Windows 节点上。
+
+你还可以使用以下 Helm 参数为 Windows 节点自定义 kruise-daemon 镜像：
+
+```bash
+$ helm install kruise https://... --set daemon.windowsImage.repository=openkruise/kruise-daemon-windows --set daemon.windowsImage.tag=v1.9.0
+```
+
 ### 可选: 中国本地镜像
 
 如果你在中国、并且很难从官方 DockerHub 上拉镜像，那么你可以使用托管在阿里云上的镜像仓库：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/cloneset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/cloneset.md
@@ -422,11 +422,12 @@ spec:
 
 ### 升级类型
 
-CloneSet 提供了 3 种升级方式，默认为 `ReCreate`：
+CloneSet 提供了 4 种升级方式，默认为 `ReCreate`：
 
 - `ReCreate`: 控制器会删除旧 Pod 和它的 PVC，然后用新版本重新创建出来。
 - `InPlaceIfPossible`: 控制器会优先尝试原地升级 Pod，如果不行再采用重建升级。当前， 仅支持容器镜像等字段的原地升级。
 - `InPlaceOnly`: 控制器只允许采用原地升级。因此，用户只能修改支持原地升级的字段，如果尝试修改其他字段会被 Kruise 拒绝。
+- `OnDelete`: **FEATURE STATE:** Kruise v1.9.0。控制器不会自动升级 Pod。只有在 Pod 被手动删除时才会进行更新。版本跟踪和有序滚动重启将被禁用。适用于需要手动控制每个 Pod 更新场景。
 **请阅读[原地升级概念](../core-concepts/inplace-update)了解更多原地升级的细节。**
 
 我们还在原地升级中提供了 **graceful period** 选项，作为优雅原地升级的策略。用户如果配置了 `gracePeriodSeconds` 这个字段，控制器在原地升级的过程中会先把 Pod status 改为 not-ready，然后等一段时间（`gracePeriodSeconds`），最后再去修改 Pod spec 中的镜像版本。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/imagepulljob.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/imagepulljob.md
@@ -255,6 +255,14 @@ spec:
 </TabItem>
 </Tabs>
 
+### 节点侧并发控制
+
+**FEATURE STATE:** Kruise v1.9.0
+
+从 v1.9.0 开始，kruise-daemon 支持节点侧的镜像拉取并发控制。该功能限制每个节点上并发拉取镜像的数量，防止当多个 ImagePullJob 同时指向同一节点时导致资源耗尽（CPU、内存、磁盘 I/O）。
+
+并发限制可以通过 kruise-daemon 的 `--max-concurrency` 参数进行配置。默认情况下，daemon 使用 worker pool 来限制每个节点上并发的镜像拉取操作。
+
 ## ImageListPullJob
 
 **FEATURE STATE:** Kruise v1.5.0

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/jobsidecarterminator.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/jobsidecarterminator.md
@@ -65,6 +65,31 @@ spec:
 
 从 Kruise 1.6.0 版本开始，将忽略 Sidecar 容器退出码 `非0` 的情况，Pod Phase 状态只依赖于 Main 容器成功与否。
 
+### 通过环境变量配置退出码忽略行为
+
+**FEATURE STATE:** Kruise v1.9.0
+
+从 v1.9.0 开始，用户可以通过在 sidecar 容器上设置 `KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE` 环境变量来显式控制是否忽略 sidecar 容器的非零退出码。
+
+- 如果设置为 `"true"`，将忽略 sidecar 容器的非零退出码，Pod Phase 只取决于主容器（与 v1.6.0 以来的默认行为相同）。
+- 如果设置为 `"false"`，sidecar 容器的退出码将影响 Pod Phase。非零退出码将导致 Pod Phase=Failed。
+
+```yaml
+kind: Job
+spec:
+  template:
+    spec:
+      containers:
+        - name: sidecar
+          env:
+            - name: KRUISE_TERMINATE_SIDECAR_WHEN_JOB_EXIT
+              value: "true"
+            - name: KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE
+              value: "false"
+        - name: main
+... ...
+```
+
 ### 注意事项
 
 - sidecar 容器必须能够响应 `SIGTERM` 信号。当收到此信号时，`EntryPoint` 进程必须退出(即 sidecar 容器退出)，且退出码应当为 `0`。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/podprobemarker.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/podprobemarker.md
@@ -70,8 +70,8 @@ spec:
 - spec.probes
     - **name**: probe名字，需要在Pod内是唯一的，哪怕不同的容器之间也需要唯一
     - **containerName**: 执行probe的容器
-    - **probe**: probe相关的API定义，与原生K8S probe一致（当前只支持
-      Exec）。详情请参考：https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+    - **probe**: probe相关的API定义，与原生K8S probe一致（当前支持
+      Exec、tcpSocket 和 HTTP 探测）。详情请参考：https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
     - **markerPolicy**: 根据Probe执行结果（Succeeded或Failed），在Pod上面打特定的Labels和Annotations。
         - state: probe结果，Succeeded 或 Failed
         - labels: 如果结果满足，打 labels 到Pod上
@@ -104,6 +104,33 @@ spec:
       containerName: game-server
       probe:
         tcpSocket:
+          port: 8080
+        initialDelaySeconds: 15
+        periodSeconds: 10
+```
+
+### 支持 HTTP Probe
+
+**FEATURE STATE:** Kruise v1.9.0
+
+从 v1.9.0 开始，PodProbeMarker 支持 HTTP 探测。根据如下配置，kruise-daemon 会向容器的指定路径和端口发送 HTTP `GET` 请求。如果响应状态码在 200 到 399 之间（含），则 Probe 返回 `Succeeded`，否则返回 `Failed`。
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: PodProbeMarker
+metadata:
+  name: game-server-probe
+  namespace: ns
+spec:
+  selector:
+    matchLabels:
+      app: game-server
+  probes:
+    - name: Idle
+      containerName: game-server
+      probe:
+        httpGet:
+          path: /healthz
           port: 8080
         initialDelaySeconds: 15
         periodSeconds: 10

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/sidecarset.md
@@ -279,6 +279,8 @@ spec:
     podInjectPolicy: BeforeAppContainer
     shareVolumePolicy:
       type: disabled | enabled
+    shareVolumeDevicePolicy:
+      type: disabled | enabled
     transferEnv:
     - sourceContainerName: main
       envName: PROXY_IP
@@ -326,6 +328,8 @@ spec:
     podInjectPolicy: BeforeAppContainer
     shareVolumePolicy:
       type: disabled | enabled
+    shareVolumeDevicePolicy:
+      type: disabled | enabled
     transferEnv:
     - sourceContainerName: main
       envName: PROXY_IP
@@ -348,11 +352,19 @@ spec:
 - 数据卷共享
     - 共享指定卷：通过 spec.volumes 来定义 sidecar 自身需要的 volume，详情请参考：https://kubernetes.io/docs/concepts/storage/volumes/
     - 共享所有卷：通过 spec.containers[i].shareVolumePolicy.type = enabled | disabled 来控制是否挂载pod应用容器的卷，常用于日志收集等 sidecar，配置为 enabled 后会把应用容器中所有挂载点注入 sidecar 同一路经下(sidecar中本身就有声明的数据卷和挂载点除外）
+    - 共享 VolumeDevice：通过 spec.containers[i].shareVolumeDevicePolicy.type = enabled | disabled 来控制是否共享 pod 应用容器的 VolumeDevices（不包含注入的 sidecar 容器）。**FEATURE STATE:** Kruise v1.9.0
 - 环境变量共享
     - 可以通过 spec.containers[i].transferEnv 来从别的容器获取环境变量，会把名为 sourceContainerName 容器中名为 envName 的环境变量拷贝到本容器
     - sourceContainerNameFrom 支持 downwardAPI 来获取容器name，比如：metadata.name, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`
 - 动态资源注入
     - 可以通过 `spec.containers[i].resourcesPolicy` 和 `spec.initContainers[i].resourcesPolicy` 来配置 sidecar 容器的资源，使得它能够根据目标Pod容器的资源动态调整。
+
+#### Sidecar 容器注入顺序
+**FEATURE STATE:** Kruise v1.9.0
+
+从 v1.9.0 开始，SidecarSet 在将 `spec.containers` 和 `spec.initContainers` 注入到 Pod 时，会按照容器名称的升序进行排序。这保证了确定的注入顺序，确保有依赖关系的 sidecar 容器能够按正确的顺序注入。
+
+例如，如果 SidecarSet 定义了名为 `envoy`、`log-agent` 和 `nginx` 的容器，它们将按以下顺序注入到 Pod 中：`envoy`, `log-agent`, `nginx`。
 
 #### 注入暂停
 **FEATURE STATE:** Kruise v0.10.0


### PR DESCRIPTION
## Summary

This PR adds documentation for OpenKruise v1.9.0 release.

### Documentation Updates (EN + ZH)
- **SidecarSet**: shareVolumeDevicePolicy, injection order sorting, dynamic resources (resourcesPolicy)
- **PodProbeMarker**: HTTP probe (httpGet) support
- **JobSidecarTerminator**: KRUISE_TERMINATE_SIDECAR_IGNORE_EXIT_CODE env var
- **ImagePullJob**: --max-concurrency flag for kruise-daemon
- **CloneSet**: OnDelete update strategy type
- **Installation**: kruise-daemon Windows node support

### Release Blog Post (EN + ZH)
- API v1alpha1 → v1beta1 migration guide in Upgrade Notice (field changes, YAML examples)
- 5 detailed Key Features with user scenarios and YAML examples:
  1. UnitedDeployment ReserveUnschedulablePods
  2. AdvancedCronJob Cron ImagePullJob
  3. CloneSet progressDeadlineSeconds
  4. SidecarSet Dynamic Resources
  5. PodUnavailableBudget RESIZE Protection
- Other Notable Changes (7 brief features)
- What's Next in v2.0 (API upgrades, ConfigMapSet preview)

### Verification
- EN/ZH consistency check passes (11 headings, 6 links, 27 bold, 67 inline code)
- `npm run build` passes with [SUCCESS]