### PR TITLE
fix: add missing kustomize-schema-generator to versioned sidebars v1.6-v1.9

### DIFF
--- a/versioned_sidebars/version-v1.6-sidebars.json
+++ b/versioned_sidebars/version-v1.6-sidebars.json
@@ -86,7 +86,8 @@
         {
           "CLI tools": [
             "cli-tool/kubectl-plugin",
-            "cli-tool/kustomize-plugin"
+            "cli-tool/kustomize-plugin",
+            "cli-tool/kustomize-schema-generator"
           ]
         }
       ]

--- a/versioned_sidebars/version-v1.7-sidebars.json
+++ b/versioned_sidebars/version-v1.7-sidebars.json
@@ -91,7 +91,8 @@
         {
           "CLI tools": [
             "cli-tool/kubectl-plugin",
-            "cli-tool/kustomize-plugin"
+            "cli-tool/kustomize-plugin",
+            "cli-tool/kustomize-schema-generator"
           ]
         }
       ]

--- a/versioned_sidebars/version-v1.8-sidebars.json
+++ b/versioned_sidebars/version-v1.8-sidebars.json
@@ -91,7 +91,8 @@
         {
           "CLI tools": [
             "cli-tool/kubectl-plugin",
-            "cli-tool/kustomize-plugin"
+            "cli-tool/kustomize-plugin",
+            "cli-tool/kustomize-schema-generator"
           ]
         }
       ]

--- a/versioned_sidebars/version-v1.9-sidebars.json
+++ b/versioned_sidebars/version-v1.9-sidebars.json
@@ -93,7 +93,8 @@
         {
           "CLI tools": [
             "cli-tool/kubectl-plugin",
-            "cli-tool/kustomize-plugin"
+            "cli-tool/kustomize-plugin",
+            "cli-tool/kustomize-schema-generator"
           ]
         }
       ]


### PR DESCRIPTION
## Description

The `kustomize-schema-generator.md` documentation page exists in all versioned docs directories (v1.6 through v1.9), but is not referenced in the corresponding `versioned_sidebars` files. Users browsing those doc versions cannot navigate to this page through the sidebar.

The current `sidebars.js` already includes this entry at line 108, establishing the correct pattern.

## Changes

Added `cli-tool/kustomize-schema-generator` to the CLI tools section in:
- version-v1.6-sidebars.json
- version-v1.7-sidebars.json
- version-v1.8-sidebars.json
- version-v1.9-sidebars.json

## Verification

- All four JSON files parse as valid JSON
- The doc file exists on disk in each corresponding `versioned_docs` directory
- The current `sidebars.js` already follows this exact pattern
