### PR TITLE
fix: log warning instead of silently swallowing exception when loading pre_dict.json in diff.py

### DIFF
--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -30,8 +30,8 @@ try:
     if os.path.exists(dict_path):
         with open(dict_path, 'r', encoding='utf8') as f:
             pre_dict = set(json.loads(f.read()))
-except Exception:
-    pass
+except Exception as e:
+    log(f"Warning: failed to load pre_dict.json: {e}")
 
 
 def log(*args) -> None:


### PR DESCRIPTION
### Description

In `.github/workflows/diff.py`, the try/except block that loads `pre_dict.json` silently swallows ALL exceptions with `except Exception: pass`. If the file is corrupted, has invalid JSON, or has permission issues, the error is completely hidden — the script continues with an empty dictionary, causing false-positive spelling errors in CI with no indication that the dictionary failed to load.

This fix logs a warning using the project's existing `log()` function, following the same pattern already established at line 63 of the same file.

### Changes
- `.github/workflows/diff.py:33-34` — Replace bare `except Exception: pass` with `except Exception as e: log(f"Warning: failed to load pre_dict.json: {e}")`

### Verification
- `python3 -m py_compile .github/workflows/diff.py` passes
- `npm run build` completes successfully (both en and zh locales)
- DCO signed-off