### PR TITLE
docs(kruiseagents): add scaleStrategy and updateStrategy maxUnavailable to warmpool-management

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
@@ -58,6 +58,46 @@ NAME   REPLICAS   AVAILABLE   UPDATEREVISION   AGE
 demo   10         10          78dd8599cf       19m
 ```
 
+## 扩容与更新策略
+
+`SandboxSet` 提供两个策略字段，用于控制扩容和滚动更新的节奏，从而尽量减少对集群资源和服务可用性的影响。
+
+### `scaleStrategy.maxUnavailable`
+
+该字段限制在 **扩容操作** 期间允许处于 **不可用** 状态（即处于 `creating` 状态）的沙箱最大数量。当你希望避免 Pod 创建突发增长对集群造成压力时，该字段非常有用。
+
+- 可以是绝对值（如 `5`）或百分比字符串（如 `"20%"`）。
+- 默认值：无限制（所有新沙箱同时创建）。
+
+```yaml
+spec:
+  replicas: 20
+  scaleStrategy:
+    # 在扩容期间，最多允许 5 个沙箱处于 creating 状态
+    maxUnavailable: 5
+```
+
+:::tip
+扩容时，新创建的沙箱会按照该限制分批启动。例如，若 `maxUnavailable: 5`，从 0 扩容到 20，沙箱会以每批 5 个的方式创建——每一批只有在上一批变为 `available` 后才会开始创建。
+:::
+
+### `updateStrategy.maxUnavailable`
+
+该字段控制在 **滚动更新** 期间（通过修改 `spec.template` 触发）允许处于 **不可用** 状态的沙箱最大数量或百分比。它决定了滚动更新的批次大小。
+
+- 可以是绝对值（如 `5`）或百分比字符串（如 `"20%"`）。
+- 默认值：`"20%"`。
+
+```yaml
+spec:
+  replicas: 10
+  updateStrategy:
+    # 在滚动更新期间，最多允许 3 个沙箱不可用
+    maxUnavailable: 3
+```
+
+关于滚动更新工作原理的详细说明，包括监控进度和故障排查，请参考 [升级预热池沙箱（SandboxSet）](./sandbox-update.md#升级预热池沙箱sandboxset)。
+
 ## 预热沙箱的获取与补充
 
 你可以通过多种方式从预热池中获取一个 available 状态的沙箱，参考 [获取沙箱](./sandbox-claim.md)。当一个沙箱被获取后，

--- a/kruiseagents/user-manuals/warmpool-management.md
+++ b/kruiseagents/user-manuals/warmpool-management.md
@@ -62,6 +62,46 @@ NAME   REPLICAS   AVAILABLE   UPDATEREVISION   AGE
 demo   10         10          78dd8599cf       19m
 ```
 
+## Scaling and Update Strategies
+
+`SandboxSet` provides two strategy fields to control the pace of scaling and rolling updates, helping to minimize the impact on cluster resources and service availability.
+
+### `scaleStrategy.maxUnavailable`
+
+This field limits the maximum number of sandboxes that can be **unavailable** (i.e., in the `creating` state) during **scaling operations**. It is useful when you want to avoid a sudden surge of Pod creation that could pressure the cluster.
+
+- Can be an absolute number (e.g., `5`) or a percentage string (e.g., `"20%"`).
+- Default: no limit (all new sandboxes are created simultaneously).
+
+```yaml
+spec:
+  replicas: 20
+  scaleStrategy:
+    # At most 5 sandboxes can be in the creating state at any time during scaling
+    maxUnavailable: 5
+```
+
+:::tip
+When scaling up, newly created sandboxes are launched in batches respecting this limit. For example, if `maxUnavailable: 5` and you scale from 0 to 20, sandboxes are created in groups of 5 — each new batch starts only after the previous batch becomes `available`.
+:::
+
+### `updateStrategy.maxUnavailable`
+
+This field controls the maximum number or percentage of sandboxes that can be **unavailable** during a **rolling update** (triggered by modifying `spec.template`). It determines the batch size of the rolling update.
+
+- Can be an absolute number (e.g., `5`) or a percentage string (e.g., `"20%"`).
+- Default: `"20%"`.
+
+```yaml
+spec:
+  replicas: 10
+  updateStrategy:
+    # At most 3 sandboxes can be unavailable during the rolling update
+    maxUnavailable: 3
+```
+
+For a detailed explanation of how rolling updates work, including monitoring progress and troubleshooting, refer to [Upgrade Pre-warmed Pool Sandboxes (SandboxSet)](./sandbox-update.md#upgrade-pre-warmed-pool-sandboxes-sandboxset).
+
 ## Claiming and Replenishing Warm Sandboxes
 
 You can claim an available sandbox from the warm pool in various ways, refer to [Sandbox Claim](./sandbox-claim.md).


### PR DESCRIPTION
## Summary

Add documentation for `scaleStrategy.maxUnavailable` and `updateStrategy.maxUnavailable` fields to the SandboxSet warm pool management doc.

## Changes

- **`scaleStrategy.maxUnavailable`**: Describes how to limit the number of sandboxes in the `creating` state during scaling operations, with a tip explaining batch creation behavior.
- **`updateStrategy.maxUnavailable`**: Describes how to control the batch size of rolling updates, with a cross-reference to the [sandbox-update](https://openkruise.io/kruiseagents/user-manuals/sandbox-update#upgrade-pre-warmed-pool-sandboxes-sandboxset) page for detailed rolling update coverage.
- Both EN and ZH versions updated.
