### PR TITLE
refactor(kruiseagents): split e2b-client page and reorganize sidebar

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/architecture.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/architecture.md
@@ -34,5 +34,32 @@ sandboxupdateops.agents.kruise.io                        2026-05-19T03:49:37Z
 ```
 
 ## E2B APIs
-OpenKruise Agents 提供了兼容E2B协议的API. 
+OpenKruise Agents 提供了兼容E2B协议的API.
 
+### E2B 兼容性说明
+
+> ⚠️ **重要**：`commands.run`（命令执行）和文件系统 `read/write` API 需要在 Sandbox 中注入 `agent-runtime` 组件。请确保你的
+> SandboxSet 已配置 `runtimes: [{name: agent-runtime}]`。详情请参考[运行时注入](./user-manuals/runtime-injection.md)文档。
+
+| API分类  | API                                                    | 参数兼容程度 | 说明                                        |
+|--------|--------------------------------------------------------|--------|-------------------------------------------|
+| 生命周期管理 | create                                                 | 部分兼容   | 网络访问控制、原地变配待实现                            |
+|        | get\_info                                              | 完全兼容   |                                           |
+|        | list                                                   | 完全兼容   |                                           |
+|        | kill                                                   | 完全兼容   |                                           |
+|        | pause                                                  | 完全兼容   | 考虑到容器生态的效率问题，当前 pause 的实现为异步接口            |
+|        | resume                                                 | 完全兼容   |                                           |
+|        | connect                                                | 完全兼容   |                                           |
+|        | set\_timeout                                           | 完全兼容   | 设置 Sandbox 超时时间（TTL），等价于 E2B 的 `Refresh sandbox` API |
+| 代码运行   | run\_code                                              | 完全兼容   | 主容器内需要运行e2b-code-interpreter              |
+| 命令执行   | commands.run                                           | 完全兼容   | 需要通过运行时注入agent-runtime组件                  |
+| 文件系统   | read/write                                             | 完全兼容   | 需要通过运行时注入agent-runtime组件                  |
+|        | upload\_url/download\_url                              | 不支持    | 通过预签名url上传下载待实现                           |
+| 日志     | logs                                                   | 不支持    | Sandbox 日志获取待实现                            |
+| 监控指标   | metrics                                                | 不支持    | Sandbox 监控指标获取待实现                          |
+| 网络     | network                                                | 不支持    | Sandbox 网络配置（出口规则）待实现                      |
+| 生命周期事件 | `https://api.e2b.app/events/sandboxes/{sbx.sandbox_id}` | 不支持    | 生命周期事件待实现                                 |
+| 快照管理   | snapshots                                              | 完全兼容   | 具体快照效果依赖于 Checkpoint 实现                   |
+| 模板管理   |                                                        | 部分兼容   | 模板读操作已支持， 模板写操作推荐使用容器镜像来替代               |
+| API密钥管理 | teams, api-keys                                        | 完全兼容   | OpenKruise Agents 扩展：基于团队的多租户 API 密钥管理     |
+| 卷管理    | volumes                                                | 不支持    | 持久化卷管理待实现                                 |

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/e2b-client.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/e2b-client.md
@@ -1,3 +1,7 @@
+---
+title: Python 客户端
+---
+
 # 使用 E2B SDK
 
 OpenKruise Agents 的 sandbox-manager 组件支持两种 E2B 接入协议：原生 E2B 协议和私有协议。
@@ -180,31 +184,3 @@ kubectl create secret tls sandbox-manager-tls \
     from kruise_agents.patch_e2b import patch_e2b
     patch_e2b(https=False)
     ```
-
-## E2B 兼容性说明
-
-> ⚠️ **重要**：`commands.run`（命令执行）和文件系统 `read/write` API 需要在 Sandbox 中注入 `agent-runtime` 组件。请确保你的
-> SandboxSet 已配置 `runtimes: [{name: agent-runtime}]`。详情请参考[运行时注入](./runtime-injection.md)文档。
-
-| API分类  | API                                                    | 参数兼容程度 | 说明                                        |
-|--------|--------------------------------------------------------|--------|-------------------------------------------|
-| 生命周期管理 | create                                                 | 部分兼容   | 网络访问控制、原地变配待实现                            |
-|        | get\_info                                              | 完全兼容   |                                           |
-|        | list                                                   | 完全兼容   |                                           |
-|        | kill                                                   | 完全兼容   |                                           |
-|        | pause                                                  | 完全兼容   | 考虑到容器生态的效率问题，当前 pause 的实现为异步接口            |
-|        | resume                                                 | 完全兼容   |                                           |
-|        | connect                                                | 完全兼容   |                                           |
-|        | set\_timeout                                           | 完全兼容   | 设置 Sandbox 超时时间（TTL），等价于 E2B 的 `Refresh sandbox` API |
-| 代码运行   | run\_code                                              | 完全兼容   | 主容器内需要运行e2b-code-interpreter              |
-| 命令执行   | commands.run                                           | 完全兼容   | 需要通过运行时注入agent-runtime组件                  |
-| 文件系统   | read/write                                             | 完全兼容   | 需要通过运行时注入agent-runtime组件                  |
-|        | upload\_url/download\_url                              | 不支持    | 通过预签名url上传下载待实现                           |
-| 日志     | logs                                                   | 不支持    | Sandbox 日志获取待实现                            |
-| 监控指标   | metrics                                                | 不支持    | Sandbox 监控指标获取待实现                          |
-| 网络     | network                                                | 不支持    | Sandbox 网络配置（出口规则）待实现                      |
-| 生命周期事件 | `https://api.e2b.app/events/sandboxes/{sbx.sandbox_id}` | 不支持    | 生命周期事件待实现                                 |
-| 快照管理   | snapshots                                              | 完全兼容   | 具体快照效果依赖于 Checkpoint 实现                   |
-| 模板管理   |                                                        | 部分兼容   | 模板读操作已支持， 模板写操作推荐使用容器镜像来替代               |
-| API密钥管理 | teams, api-keys                                        | 完全兼容   | OpenKruise Agents 扩展：基于团队的多租户 API 密钥管理     |
-| 卷管理    | volumes                                                | 不支持    | 持久化卷管理待实现                                 |

--- a/kruiseagents/architecture.md
+++ b/kruiseagents/architecture.md
@@ -6,28 +6,28 @@ The overall architecture of OpenKruise Agents is shown as below:
 
 ![alt](/img/kruiseagents/architecture.png)
 
-### sandbox-manager
+## sandbox-manager
 
 `sandbox-manager` is a stateless backend management component that provides E2B APIs and MCP APIs for
 managing and operating sandbox instances.
 
-### sandbox-gateway
+## sandbox-gateway
 
 `sandbox-gateway` is a lightweight and efficient gateway that proxy incoming traffic to the sandboxes, `sandbox-gateway` is built as an envoy filter.
 
-### sandbox-controller
+## sandbox-controller
 `sandbox-controller` contains a group of controllers responsible for the reconcilation of resources such as sandboxset and sandboxclaim, it also provides the admission webhooks for related CRD resources。
 
-### agent-runtime
+## agent-runtime
 
 `agent-runtime` is a Sidecar injected into the Sandbox that provides utilty services for the sandbox,
 including E2B envd-compatible command and file operations, dynamic CSI mounting, etc.
 
-## API
+# API
 
 OpenKruise Agents provides K8S, E2B and MCP apis.
 
-### K8S APIs
+## K8S APIs
 
 OpenKruise Agents provides  **Kubernetes API** in the forms of CRD，and they're targeting for platform builders and infrastructure teams.
 
@@ -41,5 +41,32 @@ sandboxtemplates.agents.kruise.io                        2026-05-19T03:49:37Z
 sandboxupdateops.agents.kruise.io                        2026-05-19T03:49:37Z
 ```
 
-### E2B APIs
+## E2B APIs
 OpenKruise Agents provides E2B protocol-compatible APIs
+
+### E2B Compatibility
+
+> ⚠️ **Important**: The `commands.run` (command execution) and file system `read/write` APIs require the `agent-runtime` component to be injected into the Sandbox. Please ensure that your SandboxSet has configured `runtimes: [{name: agent-runtime}]`. For details, refer to the [Runtime Injection](./user-manuals/runtime-injection.md) documentation.
+
+| API Category         | API                                                    | Compatibility Level  | Notes                                                                                                               |
+|----------------------|--------------------------------------------------------|----------------------|---------------------------------------------------------------------------------------------------------------------|
+| Lifecycle Management | create                                                 | Partially Compatible | Network access control and resource management implementation pending                                               |
+|                      | get\_info                                              | Fully Compatible     |                                                                                                                     |
+|                      | list                                                   | Fully Compatible     |                                                                                                                     |
+|                      | kill                                                   | Fully Compatible     |                                                                                                                     |
+|                      | pause                                                  | Fully Compatible     | Due to container ecosystem efficiency considerations, current pause implementation is asynchronous                  |
+|                      | resume                                                 | Fully Compatible     |                                                                                                                     |
+|                      | connect                                                | Fully Compatible     |                                                                                                                     |
+|                      | set\_timeout                                           | Fully Compatible     | Set the sandbox timeout (TTL), equivalent to E2B's `Refresh sandbox` API                                           |
+| Code Execution       | run\_code                                              | Fully Compatible     | Requires e2b-code-interpreter running in main container                                                             |
+| Command Execution    | commands.run                                           | Fully Compatible     | Requires runtime injection of agent-runtime component                                                               |
+| File System          | read/write                                             | Fully Compatible     | Requires runtime injection of agent-runtime component                                                               |
+|                      | upload\_url/download\_url                              | Not Supported        | Upload/download via pre-signed URL implementation pending                                                           |
+| Logs                 | logs                                                   | Not Supported        | Sandbox logs retrieval implementation pending                                                                       |
+| Metrics              | metrics                                                | Not Supported        | Sandbox metrics retrieval implementation pending                                                                    |
+| Network              | network                                                | Not Supported        | Sandbox network configuration (egress rules) implementation pending                                                 |
+| Lifecycle Events     | `https://api.e2b.app/events/sandboxes/{sbx.sandbox_id}` | Not Supported        | Lifecycle events implementation pending                                                                             |
+| Snapshot Management  | snapshots                                              | Fully Compatible     | Specific snapshot behavior depends on Checkpoint implementation                                                     |
+| Template Management  |                                                        | Partially Compatible | Template read supported, template write is not supported by design, recommend using container images as alternative |
+| API Keys Management  | teams, api-keys                                        | Fully Compatible     | OpenKruise Agents extension: multi-tenant API key management with team-based access control                        |
+| Volumes              | volumes                                                | Not Supported        | Persistent volume management implementation pending                                                                 |

--- a/kruiseagents/user-manuals/e2b-client.md
+++ b/kruiseagents/user-manuals/e2b-client.md
@@ -1,3 +1,7 @@
+---
+title: Python Client
+---
+
 # Using the E2B SDK
 
 The sandbox-manager component of OpenKruise Agents supports two E2B integration protocols: native E2B protocol and
@@ -189,29 +193,3 @@ kubectl create secret tls sandbox-manager-tls \
     patch_e2b(https=False)
     ```
 
-## E2B Compatibility
-
-> ⚠️ **Important**: The `commands.run` (command execution) and file system `read/write` APIs require the `agent-runtime` component to be injected into the Sandbox. Please ensure that your SandboxSet has configured `runtimes: [{name: agent-runtime}]`. For details, refer to the [Runtime Injection](./runtime-injection.md) documentation.
-
-| API Category         | API                                                    | Compatibility Level  | Notes                                                                                                               |
-|----------------------|--------------------------------------------------------|----------------------|---------------------------------------------------------------------------------------------------------------------|
-| Lifecycle Management | create                                                 | Partially Compatible | Network access control and resource management implementation pending                                               |
-|                      | get\_info                                              | Fully Compatible     |                                                                                                                     |
-|                      | list                                                   | Fully Compatible     |                                                                                                                     |
-|                      | kill                                                   | Fully Compatible     |                                                                                                                     |
-|                      | pause                                                  | Fully Compatible     | Due to container ecosystem efficiency considerations, current pause implementation is asynchronous                  |
-|                      | resume                                                 | Fully Compatible     |                                                                                                                     |
-|                      | connect                                                | Fully Compatible     |                                                                                                                     |
-|                      | set\_timeout                                           | Fully Compatible     | Set the sandbox timeout (TTL), equivalent to E2B's `Refresh sandbox` API                                           |
-| Code Execution       | run\_code                                              | Fully Compatible     | Requires e2b-code-interpreter running in main container                                                             |
-| Command Execution    | commands.run                                           | Fully Compatible     | Requires runtime injection of agent-runtime component                                                               |
-| File System          | read/write                                             | Fully Compatible     | Requires runtime injection of agent-runtime component                                                               |
-|                      | upload\_url/download\_url                              | Not Supported        | Upload/download via pre-signed URL implementation pending                                                           |
-| Logs                 | logs                                                   | Not Supported        | Sandbox logs retrieval implementation pending                                                                       |
-| Metrics              | metrics                                                | Not Supported        | Sandbox metrics retrieval implementation pending                                                                    |
-| Network              | network                                                | Not Supported        | Sandbox network configuration (egress rules) implementation pending                                                 |
-| Lifecycle Events     | `https://api.e2b.app/events/sandboxes/{sbx.sandbox_id}` | Not Supported        | Lifecycle events implementation pending                                                                             |
-| Snapshot Management  | snapshots                                              | Fully Compatible     | Specific snapshot behavior depends on Checkpoint implementation                                                     |
-| Template Management  |                                                        | Partially Compatible | Template read supported, template write is not supported by design, recommend using container images as alternative |
-| API Keys Management  | teams, api-keys                                        | Fully Compatible     | OpenKruise Agents extension: multi-tenant API key management with team-based access control                        |
-| Volumes              | volumes                                                | Not Supported        | Persistent volume management implementation pending                                                                 |

--- a/sidebars-kruiseagents.js
+++ b/sidebars-kruiseagents.js
@@ -34,7 +34,6 @@ module.exports = {
                 'user-manuals/checkpoint',
                 'user-manuals/sandbox-update',
                 'user-manuals/api-keys-and-teams',
-                'user-manuals/e2b-client'
             ],
         },
         {
@@ -69,6 +68,7 @@ module.exports = {
                 'developer-manuals/contribution',
                 {
                     'E2B SDK': [
+                        'user-manuals/e2b-client',
                         "developer-manuals/e2b-client",
                         "developer-manuals/e2b-client-java",
                     ],


### PR DESCRIPTION
## Summary

- Move **E2B Compatibility** section from `user-manuals/e2b-client.md` to `architecture.md` under the E2B APIs heading (`#e2b-apis` anchor)
- Move the remaining **Python Client** content (`user-manuals/e2b-client`) into the sidebar under **Developer Manuals → E2B SDK → Python Client** (removed from User Manuals section)
- Align EN `architecture.md` heading levels with the ZH source of truth (`##` for components, `#` for API, `##` for K8S/E2B APIs, `###` for E2B Compatibility)
- Add localized ZH title `Python 客户端` as frontmatter for the Python Client page