### PR TITLE
docs(kruiseagents): add v0.3.0 extension metadata docs for sandbox-claim and checkpoint

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/checkpoint.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/checkpoint.md
@@ -260,6 +260,48 @@ const newSandbox = await Sandbox.create(snapshot.snapshotId)
 </TabItem>
 </Tabs>
 
+#### 沙箱命名（v0.3.0+）
+
+:::note
+**v0.3.0+**：自定义沙箱命名仅在从 Checkpoint 创建沙箱（克隆路径）时支持。
+从 SandboxSet 预热池获取沙箱时**不可用**——请求将被拒绝。
+:::
+
+从 Checkpoint 创建沙箱时，可以控制新沙箱的名称，而不必依赖系统自动生成的随机名称。
+
+> `e2b.agents.kruise.io/sandbox-name` 和 `e2b.agents.kruise.io/sandbox-generate-name` 为 OpenKruise Agents
+> 扩展字段，不会作为元数据添加到 Sandbox 资源上。
+
+**固定名称：**
+
+使用 `e2b.agents.kruise.io/sandbox-name` 为沙箱指定一个固定名称。名称必须是合法的
+[Kubernetes DNS-1123 标签](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)
+（最多 63 个字符，小写字母数字或 `-`，必须以字母数字开头和结尾）。
+
+```python
+from e2b_code_interpreter import Sandbox
+
+new_sbx = Sandbox.create(template=snapshot.snapshot_id, metadata={
+    "e2b.agents.kruise.io/sandbox-name": "my-restored-sandbox"
+})
+```
+
+**自动生成名称：**
+
+使用 `e2b.agents.kruise.io/sandbox-generate-name` 指定名称前缀，系统会自动追加一个 5 位的随机后缀
+（如 `fork-` → `fork-abcde`）。前缀必须以 `-` 结尾，并遵循相同的 DNS-1123 标签规则。
+
+```python
+from e2b_code_interpreter import Sandbox
+
+new_sbx = Sandbox.create(template=snapshot.snapshot_id, metadata={
+    "e2b.agents.kruise.io/sandbox-generate-name": "fork-"
+})
+# new_sbx.sandbox_id 可能是 "default--fork-x7k9a"
+```
+
+> `sandbox-name` 和 `sandbox-generate-name` **互斥**。若同时指定两者，请求将被拒绝并返回错误。
+
 完整的 claim 选项请参考 [获取沙箱](./sandbox-claim.md)。
 
 ## Checkpoint vs. SandboxTemplate / SandboxSet

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/sandbox-claim.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/sandbox-claim.md
@@ -509,6 +509,28 @@ spec:
   </TabItem>
 </Tabs>
 
+:::note
+**v0.3.0+**：E2B SDK 支持更灵活的变体 `e2b.agents.kruise.io/reserve-failed-sandbox-for`，接受细粒度的时间值而非布尔值：
+
+| 值                | 行为                                                |
+|-------------------|-----------------------------------------------------|
+| `"never"`         | 不保留失败沙箱（与默认行为一致）                      |
+| `"forever"`       | 永久保留（与 `reserve-failed-sandbox: "true"` 等效） |
+| `"600s"`、`"10m"` | 按指定的 Go duration 保留，到期后自动删除             |
+
+```python
+from e2b_code_interpreter import Sandbox
+
+# 保留失败沙箱 10 分钟，而非永久保留
+sbx = Sandbox.create(template="some-template", timeout=300, metadata={
+    "e2b.agents.kruise.io/reserve-failed-sandbox-for": "10m"
+})
+```
+
+> `e2b.agents.kruise.io/reserve-failed-sandbox-for` 与 `e2b.agents.kruise.io/reserve-failed-sandbox` 互斥。
+> 若两者同时存在，`reserve-failed-sandbox-for` 优先。
+:::
+
 ### 环境变量注入
 
 你可以在获取沙箱时注入环境变量。这些环境变量将传递给 `agent-runtime` 用于初始化。该功能需要启用 `agent-runtime`。
@@ -581,3 +603,28 @@ spec:
 
   </TabItem>
 </Tabs>
+
+### 返回沙箱 IP（v0.3.0+）
+
+:::note
+**v0.3.0+**：该功能从 OpenKruise Agents v0.3.0 开始提供，需要通过 E2B SDK 使用，`SandboxClaim` CRD 不支持此功能。
+:::
+
+获取沙箱时，可以选择在创建响应中获取沙箱 Pod 的 IP 地址。这在需要通过集群内 IP 直接连接沙箱、绕过流量代理的场景中非常有用。
+
+> `e2b.agents.kruise.io/return-sandbox-ip` 为 OpenKruise Agents 扩展字段，不会作为元数据添加到 Sandbox 资源上。
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sbx = Sandbox.create(template="demo", metadata={
+    "e2b.agents.kruise.io/return-sandbox-ip": "true"
+})
+
+# 沙箱 IP 通过 SandboxInfo 对象的 metadata 返回，key 为 "e2b.agents.kruise.io/sandbox-ip"
+info = sbx.get_info()
+pod_ip = info.metadata.get("e2b.agents.kruise.io/sandbox-ip")
+print("沙箱 Pod IP:", pod_ip)
+```
+
+> 返回的 IP 是集群内的 Pod IP，仅在同一个 Kubernetes 集群内可路由。

--- a/kruiseagents/user-manuals/checkpoint.md
+++ b/kruiseagents/user-manuals/checkpoint.md
@@ -279,6 +279,51 @@ const newSandbox = await Sandbox.create(snapshot.snapshotId)
 </TabItem>
 </Tabs>
 
+#### Sandbox Naming (v0.3.0+)
+
+:::note
+**v0.3.0+**: Custom sandbox naming is only supported when creating a sandbox from a Checkpoint (clone path).
+It is **not** available when claiming from a SandboxSet warm pool — the request will be rejected.
+:::
+
+When creating a sandbox from a Checkpoint, you can control the resulting sandbox name instead of relying on a
+randomly generated one.
+
+> `e2b.agents.kruise.io/sandbox-name` and `e2b.agents.kruise.io/sandbox-generate-name` are OpenKruise Agents
+> extension fields and will not be added to the Sandbox resource as metadata.
+
+**Explicit name:**
+
+Use `e2b.agents.kruise.io/sandbox-name` to assign a fixed name. The name must be a valid
+[Kubernetes DNS-1123 label](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)
+(at most 63 characters, lowercase alphanumeric or `-`, must start and end with an alphanumeric character).
+
+```python
+from e2b_code_interpreter import Sandbox
+
+new_sbx = Sandbox.create(template=snapshot.snapshot_id, metadata={
+    "e2b.agents.kruise.io/sandbox-name": "my-restored-sandbox"
+})
+```
+
+**Generated name:**
+
+Use `e2b.agents.kruise.io/sandbox-generate-name` to assign a name prefix. A random 5-character suffix will be
+appended automatically (e.g., `fork-` → `fork-abcde`). The prefix must end with `-` and follow the same DNS-1123
+label rules.
+
+```python
+from e2b_code_interpreter import Sandbox
+
+new_sbx = Sandbox.create(template=snapshot.snapshot_id, metadata={
+    "e2b.agents.kruise.io/sandbox-generate-name": "fork-"
+})
+# new_sbx.sandbox_id might be "default--fork-x7k9a"
+```
+
+> `sandbox-name` and `sandbox-generate-name` are **mutually exclusive**. If both are specified, the request will be
+> rejected with an error.
+
 See [Claiming Sandboxes](./sandbox-claim.md) for the full set of claim-time options.
 
 ## Checkpoint vs. SandboxTemplate / SandboxSet

--- a/kruiseagents/user-manuals/sandbox-claim.md
+++ b/kruiseagents/user-manuals/sandbox-claim.md
@@ -548,6 +548,29 @@ spec:
   </TabItem>
 </Tabs>
 
+:::note
+**v0.3.0+**: The E2B SDK supports a more flexible variant `e2b.agents.kruise.io/reserve-failed-sandbox-for` that accepts
+fine-grained duration values instead of a boolean:
+
+| Value             | Behavior                                                |
+|-------------------|---------------------------------------------------------|
+| `"never"`         | Do not reserve failed sandboxes (same as default)       |
+| `"forever"`       | Reserve indefinitely (same as `reserve-failed-sandbox: "true"`) |
+| `"600s"`, `"10m"` | Reserve for the specified Go duration, then auto-delete |
+
+```python
+from e2b_code_interpreter import Sandbox
+
+# Reserve a failed sandbox for 10 minutes instead of forever
+sbx = Sandbox.create(template="some-template", timeout=300, metadata={
+    "e2b.agents.kruise.io/reserve-failed-sandbox-for": "10m"
+})
+```
+
+> `e2b.agents.kruise.io/reserve-failed-sandbox-for` and `e2b.agents.kruise.io/reserve-failed-sandbox` are mutually
+> exclusive. If both are present, `reserve-failed-sandbox-for` takes precedence.
+:::
+
 ### Environment Variables
 
 You can inject environment variables into the sandbox when claiming. These environment variables will be passed to
@@ -624,3 +647,32 @@ spec:
 
   </TabItem>
 </Tabs>
+
+### Return Sandbox IP (v0.3.0+)
+
+:::note
+**v0.3.0+**: This feature is available from OpenKruise Agents v0.3.0 and requires the E2B SDK. It is not supported
+via `SandboxClaim` CRD.
+:::
+
+When claiming a sandbox, you can opt in to receiving the sandbox Pod's IP address in the create response. This is
+useful when you need to connect to the sandbox via its in-cluster IP directly, bypassing the traffic proxy.
+
+> `e2b.agents.kruise.io/return-sandbox-ip` is an OpenKruise Agents extension field and will not be added to the
+> Sandbox resource as metadata.
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sbx = Sandbox.create(template="demo", metadata={
+    "e2b.agents.kruise.io/return-sandbox-ip": "true"
+})
+
+# The sandbox IP is returned in the metadata of the SandboxInfo object
+# under the key "e2b.agents.kruise.io/sandbox-ip"
+info = sbx.get_info()
+pod_ip = info.metadata.get("e2b.agents.kruise.io/sandbox-ip")
+print("Sandbox Pod IP:", pod_ip)
+```
+
+> The returned IP is the Pod IP inside the cluster. It is only routable from within the same Kubernetes cluster.


### PR DESCRIPTION
## Summary

Adds documentation for new extension metadata fields introduced in **v0.3.0**, covering both  and  (EN + ZH).

### New sections

| Extension | Location | Description |
|---|---|---|
| `reserve-failed-sandbox-for` | sandbox-claim.md → Troubleshooting | Duration-based variant of `reserve-failed-sandbox`: accepts `never`, `forever`, or Go duration strings |
| `return-sandbox-ip` | sandbox-claim.md → Return Sandbox IP | Returns sandbox Pod IP via `sbx.get_info().metadata` |
| `sandbox-name` / `sandbox-generate-name` | checkpoint.md → Creating a Sandbox from a Checkpoint | Custom sandbox naming (clone-path only; rejected in claim path with 400) |

### Key decisions

- **Sandbox Naming** is documented in `checkpoint.md` (not `sandbox-claim.md`) because `createSandboxWithClaim` in `create.go` explicitly rejects these fields — they only work in the clone path.
- All code examples use `sbx.get_info().metadata.get(...)` (not `sbx.metadata`) since the E2B Python SDK `Sandbox` instance does not store metadata as a direct attribute.
- All new sections are marked with **v0.3.0+** version requirement.

### Files changed

- `kruiseagents/user-manuals/sandbox-claim.md` (EN)
- `kruiseagents/user-manuals/checkpoint.md` (EN)
- `i18n/zh/.../user-manuals/sandbox-claim.md` (ZH)
- `i18n/zh/.../user-manuals/checkpoint.md` (ZH)
