### PR TITLE
chore: add blog-for-release skill for release blog post automation

### DIFF
--- a/.qoder/skills/blog-for-release/SKILL.md
+++ b/.qoder/skills/blog-for-release/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: blog-for-release
+description: Write and submit release blog posts for OpenKruise and its sub-projects (Kruise Rollouts, KruiseGame, Kruise Agents). Use when creating release announcements, drafting version blog posts, or when the user mentions release blog, version announcement, or changelog summary.
+---
+
+# Blog for Release
+
+End-to-end workflow for writing release blog posts (EN + ZH) for OpenKruise and its sub-projects on the Docusaurus documentation site.
+
+## Workflow Overview
+
+```
+1. Research      → Fetch changelog, read docs, identify features
+2. Plan          → Map features to blog sections
+3. Write EN      → Draft with user scenarios + YAML examples
+4. Write ZH      → Mirror structure with matching element counts
+5. Verify        → Consistency check + npm run build
+6. Submit PR     → Commit, push, create PR to master
+```
+
+## Step 1: Identify the Product
+
+Determine which product's release blog you're writing:
+
+| Product | Docs dir | GitHub repo | Changelog URL | Chart dir in `openkruise/charts` |
+|---------|----------|-------------|---------------|----------------------------------|
+| **Kruise (core)** | `docs/` | `openkruise/kruise` | `openkruise/kruise/blob/master/CHANGELOG.md` | `versions/kruise/<version>/` |
+| **Kruise Rollouts** | `rollouts/` | `openkruise/rollouts` | `openkruise/rollouts/blob/master/CHANGELOG.md` | `versions/kruise-rollout/<version>/` |
+| **KruiseGame** | `kruisegame/` | `openkruise/kruise-game` | `openkruise/kruise-game/blob/master/CHANGELOG.md` | `versions/kruise-game/<version>/` |
+| **Kruise Agents** | `kruiseagents/` | `openkruise/agents` | `openkruise/agents/blob/master/CHANGELOG.md` | `versions/kruise-agents-sandbox-controller/<version>/` + `versions/kruise-agents-sandbox-manager/<version>/` |
+
+## Step 2: Research
+
+Gather source material:
+
+- **Changelog**: Fetch from the product's GitHub repo (see table above)
+- **Helm chart updates**: Check the product's chart directory in `https://github.com/openkruise/charts` for installation changes:
+  - **`Chart.yaml`**: Check `appVersion`, chart `version`, and `annotations.artifacthub.io/changes` for a curated change summary
+  - **`values.yaml`**: Compare the new version's `values.yaml` against the previous version to identify new/changed/removed configuration options (e.g., new feature gates, new controller settings, changed defaults)
+  - Fetch via raw URL: `https://raw.githubusercontent.com/openkruise/charts/master/versions/<chart-dir>/<version>/Chart.yaml` (and `values.yaml`)
+- **Existing docs**: Read the product's `user-manuals/` directory for feature details
+- **API changes**: Read `config/crd/bases` folder of each product's repo for field-level change info
+- **Master branch**: Check GitHub for upcoming features (e.g., proposals, PRs) for the "What's Next" section
+
+Compare changelog Key Features and chart changes against documented features to identify gaps that need new documentation. Chart `values.yaml` changes often reveal new configuration options that need to be highlighted in the blog's Upgrade Notice or Key Features section.
+
+## Step 3: Plan Blog Structure
+
+Use this exact section structure:
+
+| Section                   | Content                                                                  | Detail Level  |
+|---------------------------|--------------------------------------------------------------------------|---------------|
+| **Upgrade Notice**        | K8s/Go dependency changes, API changes (field changes + YAML examples)   | Medium        |
+| **Key Features**          | 5 official changelog Key Features with user scenarios, YAML, limitations | Detailed      |
+| **Other Notable Changes** | Additional features as 1-2 sentence bullet points                        | Brief         |
+| **Other Improvements**    | Bug fix summary with changelog link                                      | One paragraph |
+| **What's Next in **       | Upcoming major features from master                                      | Brief         |
+
+### Key Feature Writing Pattern
+
+Each Key Feature section must include:
+
+1. **User scenario**: Why this feature matters — real operational pain point
+2. **YAML example**: Practical, copy-pasteable configuration
+3. **Limitation/Note**: Known constraints or caveats
+
+Example structure:
+```markdown
+### Feature Name
+
+[User scenario paragraph explaining the problem and solution]
+
+```yaml
+apiVersion: ...
+kind: ...
+spec:
+  ...
+```
+
+[Explanation of what the YAML does]
+
+**Limitation**: [Known constraints]
+
+### What's Next Section
+
+Preview upcoming features from the master branch:
+- APIs planned for v1beta1 promotion
+- New CRDs under development (include spec preview if available)
+- Add **Note** that APIs/features may change before release
+
+## Step 4: Write English Blog Post
+
+### Filename and Frontmatter
+
+**Kruise (core):**
+```
+blog/YYYY-MM-DD-release-X.Y.md
+```
+```yaml
+---
+slug: openkruise-X.Y
+title: "<Product Name> vX.Y.Z: [Highlights]"
+tags: [release]
+---
+```
+
+**Sub-projects (Rollouts / Game / Agents):**
+```
+blog/YYYY-MM-DD-<product>-vX.Y.Z.md
+```
+```yaml
+---
+title: "<Product Name> vX.Y.Z: [Highlights]"
+date: YYYY-MM-DD
+tags: [release]
+---
+```
+
+Product name mappings:
+- `rollouts` → "Kruise Rollouts"
+- `game` → "OpenKruiseGame"
+- `agents` → "OpenKruise Agents"
+
+**Date**: Use the actual release date. Confirm with the user before writing.
+
+**Intro paragraph**: Brief overview linking to changelog, mentioning key themes.
+
+**Content rules**:
+- Include real-world operational rationale (e.g., "nodes GC images due to disk pressure in large model clusters")
+- Use `apiVersion` in all YAML examples (required by CI struct-check)
+- Keep YAML examples concise but realistic
+
+## Step 5: Write Chinese Blog Post
+
+Create `i18n/zh/docusaurus-plugin-content-blog/YYYY-MM-DD-release-X.Y.md` with:
+- Identical structure to EN version
+- Same heading/link/bold/inline-code counts (critical for CI)
+- Translated YAML comments but same field names
+
+## Step 6: Verify
+
+### Consistency Check
+
+Run the consistency checker:
+
+```bash
+python3 scripts/check_consistency.py blog/YYYY-MM-DD-release-X.Y.md \
+  i18n/zh/docusaurus-plugin-content-blog/YYYY-MM-DD-release-X.Y.md
+```
+
+Expected output: `Match: True` with identical counts for headings, links, bold, and inline code.
+
+If mismatched:
+1. Find the discrepancy (often a stray backtick in one language)
+2. Fix the file with the extra element
+3. Re-run until matched
+
+### Build Check
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+Must show `[SUCCESS]`. Pre-existing broken anchor warnings are acceptable.
+
+## Step 7: Submit PR
+
+```bash
+git checkout -b docs/vX.Y.Z-release
+git add blog/YYYY-MM-DD-release-X.Y.md \
+  i18n/zh/docusaurus-plugin-content-blog/YYYY-MM-DD-release-X.Y.md \
+  [other modified doc files...]
+git commit -s -m "docs: add vX.Y.Z release documentation and blog post"
+git push <fork> docs/vX.Y.Z-release
+gh pr create --repo openkruise/openkruise.io --base master \
+  --head <user>:docs/vX.Y.Z-release \
+  --title "docs: add vX.Y.Z release documentation and blog post" \
+  --body "..."
+```
+
+## Editorial Guidelines (from community feedback)
+
+1. **Don't translate the changelog** — write user-centric content with scenarios, examples and values
+2. **Key Features = detailed** — user scenarios, practical YAML, limitations
+3. **Other features = brief** — one or two sentences only
+4. **Include ALL changelog Key Features** — not just undocumented ones
+5. **API changes goes in Upgrade Notice** — not as a standalone Key Feature
+6. **What's Next section** — immediately before Get Involved, preview next version
+7. **Use actual release date** — verify with the user before writing
+
+## Common Pitfalls
+
+| Pitfall | How to Avoid |
+|---------|-------------|
+| EN/ZH inline code count mismatch | Watch for stray backticks in one language (e.g., `` `v1beta1` `` vs `v1beta1`) |
+| Wrong blog filename date | Confirm release date with user; filename must match |
+| API migration as Key Feature | Place in Upgrade Notice section |
+| Missing apiVersion in YAML | Always include `apiVersion` — CI struct-check requires it |
+| Stale changelog Key Features | Fetch fresh from GitHub, don't rely on memory |
+
+## Reference Files
+
+- Blog directory: `blog/`
+- ZH blog directory: `i18n/zh/docusaurus-plugin-content-blog/`
+- Upgrade guide (Kruise core): `docs/operator-manuals/upgrade.md`
+- blog example: `blog/2023-04-18-release-1.4.md` (v1.4 format reference)
+- Consistency script: `scripts/check_consistency.py`

--- a/.qoder/skills/blog-for-release/scripts/check_consistency.py
+++ b/.qoder/skills/blog-for-release/scripts/check_consistency.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Check EN/ZH blog post consistency for CI typo-check compliance.
+
+Compares heading counts, link counts, bold text counts, and inline code counts
+between English and Chinese versions of a blog post.
+
+Usage:
+    python3 check_consistency.py <en_file> <zh_file>
+
+Exit codes:
+    0 = Match (all counts identical)
+    1 = Mismatch (at least one count differs)
+    2 = File not found
+"""
+import re
+import sys
+
+
+def analyze(path):
+    with open(path, "r") as f:
+        content = f.read()
+
+    # Remove fenced code blocks (``` ... ```)
+    content_no_code = re.sub(r"```[\s\S]*?```", "", content)
+
+    headings = len(re.findall(r"^#{1,6}\s", content_no_code, re.MULTILINE))
+    links = len(re.findall(r"\[([^\]]*)\]\(([^)]+)\)", content_no_code))
+    bold = len(re.findall(r"\*\*[^*]+\*\*", content_no_code))
+    inline = len(re.findall(r"`[^`]+`", content_no_code))
+
+    return (headings, links, bold, inline)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <en_file> <zh_file>", file=sys.stderr)
+        sys.exit(2)
+
+    en_path, zh_path = sys.argv[1], sys.argv[2]
+
+    try:
+        en = analyze(en_path)
+    except FileNotFoundError:
+        print(f"EN file not found: {en_path}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        zh = analyze(zh_path)
+    except FileNotFoundError:
+        print(f"ZH file not found: {zh_path}", file=sys.stderr)
+        sys.exit(2)
+
+    print(
+        f"EN: headings={en[0]}, links={en[1]}, bold={en[2]}, inline={en[3]}"
+    )
+    print(
+        f"ZH: headings={zh[0]}, links={zh[1]}, bold={zh[2]}, inline={zh[3]}"
+    )
+
+    if en == zh:
+        print("Match: True")
+        sys.exit(0)
+    else:
+        print("Match: False")
+        # Show which counts differ
+        labels = ["headings", "links", "bold", "inline"]
+        for i, label in enumerate(labels):
+            if en[i] != zh[i]:
+                print(f"  MISMATCH: {label} EN={en[i]} ZH={zh[i]} (diff={abs(en[i] - zh[i])})")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this PR does

Adds a Qoder skill that provides an end-to-end workflow for writing release blog posts (EN + ZH) for OpenKruise and its sub-projects (Kruise, Rollouts, KruiseGame, Kruise Agents).

## Files added

- `.qoder/skills/blog-for-release/SKILL.md` — Step-by-step workflow covering:
  - Changelog research and Helm chart analysis
  - Blog structure planning (Upgrade Notice, Key Features, Other Changes, What's Next)
  - EN/ZH dual-language writing with CI consistency requirements
  - Build verification and PR submission
  - Editorial guidelines from community feedback

- `.qoder/skills/blog-for-release/scripts/check_consistency.py` — Validates EN/ZH blog post element counts (headings, links, bold, inline code) to ensure CI typo-check compliance before submission

## Motivation

Standardize the release blog post writing process across all OpenKruise sub-projects, ensuring consistent structure, CI compliance, and bilingual quality.