### PR TITLE
docs: refine authoring guidance, E2B access, and key migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,215 +2,61 @@
 
 Guidance for AI agents working on the OpenKruise documentation website.
 
-## Project Overview
+## Scope and precedence
 
-This is the official documentation website for [OpenKruise](https://openkruise.io), hosted at `https://openkruise.io`. It is built with **Docusaurus 3** and covers four related products, each with its own docs section, sidebar, and route prefix:
+- This file applies repository-wide. Nested `AGENTS.md` files add only local rules; follow both, with the nearest file taking precedence for local details.
+- Keep this tree boundary-based instead of repeating the same workflow in topic subdirectories.
+- `.docusaurus/`, `build/`, `node_modules/`, `venv/`, and `.qoder/` are generated content, dependencies, or tool instructions—not documentation sources.
 
-| Product | Docs directory | Route prefix | Sidebar file | i18n plugin id |
-|---------|---------------|--------------|--------------|----------------|
-| Kruise (core) | `docs/` | `/docs` | `sidebars.js` | `content-docs` |
-| Kruise Rollouts | `rollouts/` | `/rollouts` | `sidebars-rollouts.js` | `content-docs-rollouts` |
-| OpenKruiseGame | `kruisegame/` | `/kruisegame` | `sidebars-kruisegame.js` | `content-docs-kruisegame` |
-| Kruise Agents | `kruiseagents/` | `/kruiseagents` | `sidebars-kruiseagents.js` | `content-docs-kruiseagents` |
+## Content map
 
-The site supports two locales: **English** (`en`, default) and **Simplified Chinese** (`zh`).
+The Docusaurus site uses English as the default locale and Simplified Chinese as the second locale.
 
-## Tech Stack
+| Content | English source | Simplified Chinese mirror | Navigation |
+| --- | --- | --- | --- |
+| Kruise | `docs/` | `i18n/zh/docusaurus-plugin-content-docs/current/` | `sidebars.js` |
+| Kruise Rollouts | `rollouts/` | `i18n/zh/docusaurus-plugin-content-docs-rollouts/current/` | `sidebars-rollouts.js` |
+| OpenKruiseGame | `kruisegame/` | `i18n/zh/docusaurus-plugin-content-docs-kruisegame/current/` | `sidebars-kruisegame.js` |
+| Kruise Agents | `kruiseagents/` | `i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/` | `sidebars-kruiseagents.js` |
+| Blog | `blog/` | `i18n/zh/docusaurus-plugin-content-blog/` | Blog metadata/front matter |
+| Released Kruise docs | `versioned_docs/version-vX.Y/` | `i18n/zh/docusaurus-plugin-content-docs/version-vX.Y/` | `versioned_sidebars/` |
+| Standalone pages | `src/pages/` | `src/pages/zh/` | File-based routing |
 
-- **Framework**: Docusaurus 3 (`@docusaurus/core` ^3.9.2)
-- **Preset**: `@docusaurus/preset-classic`
-- **UI**: React 19, Infima CSS framework (Docusaurus classic theme)
-- **Search**: Algolia DocSearch (`@docusaurus/theme-search-algolia`)
-- **Syntax highlighting**: prism-react-renderer (themes: github/dracula)
-- **Package manager**: npm (lockfile: `package-lock.json`)
-- **Node version**: 20 (as required by CI)
+The four product documentation roots are independent plugins with separate routes and sidebars. Do not move content between them merely because topics are related.
 
-## Build & Development Commands
+## Bilingual contract
+
+- Treat each user-facing Markdown or MDX file and its same-relative-path counterpart as one bilingual document. Add, rename, move, edit, or delete both in the same change.
+- Keep behavior, defaults, limitations, examples, and release scope semantically equivalent. Translate prose naturally; preserve commands, API names, YAML fields, resource names, URLs, and code identifiers unless a localized equivalent is intentional.
+- Keep structure aligned: heading hierarchy and count, links and intended targets, emphasis, inline code, admonitions, tabs, code blocks, and route-defining front matter.
+- Apply semantic corrections to both languages. If a counterpart intentionally should not exist, explain why in the change description; historical gaps do not justify new drift.
+
+## Authoring rules
+
+- Use Docusaurus-compatible Markdown/MDX and preserve existing component and admonition syntax.
+- Keep existing routes stable unless the task changes them. Align route-defining front matter such as `id`, `slug`, and positions; translate user-facing titles and descriptions where appropriate.
+- Use fenced `yaml` blocks for Kubernetes examples and include `apiVersion`; CI validates their fields against upstream Go structs.
+- Use valid repository-relative or route links. Keep shared assets under the matching `static/img/` area unless a localized image is needed.
+- Register new product documentation pages in the matching sidebar unless they are intentionally direct-link-only.
+- Make focused edits; do not reformat unrelated prose, examples, or translations.
+
+## Version boundaries
+
+- `docs/` and its Chinese `current/` mirror describe the unreleased Kruise version.
+- Released documents and sidebars are snapshots. Change them only for an explicit backport, updating the matching English and Chinese version together.
+- Create versions through Docusaurus versioning commands rather than manually copying snapshot trees.
+
+## Validation
 
 ```bash
-# Install dependencies
-npm install
-
-# Start dev server (English)
-npm run start
-
-# Start dev server (Chinese)
-npm run start -- --locale zh
-
-# Production build (outputs to build/)
+git diff --check
 npm run build
-
-# Serve the built site locally
-npm run serve
-
-# Deploy to GitHub Pages (requires SSH + GIT_USER)
-GIT_USER=<username> USE_SSH=true npm run deploy
-
-# Clear Docusaurus cache (.docusaurus, .cache-loader)
-npm run clear
-
-# Generate translation files
-npm run write-translations
-
-# Generate heading IDs for docs
-npm run write-heading-ids
 ```
 
-## Repository Structure
+Before finishing, inspect the changed-file list for missing bilingual counterparts and address warnings introduced by the change. Run relevant `.github/workflows/` checks when changing consistency tooling.
 
-```
-.
-├── docusaurus.config.js      # Main site configuration (navbar, footer, i18n, plugins)
-├── versions.json             # Released doc versions (e.g. ["v1.9","v1.8","v1.7","v1.6"])
-├── sidebars.js               # Kruise core sidebar
-├── sidebars-rollouts.js      # Rollouts sidebar
-├── sidebars-kruisegame.js    # KruiseGame sidebar
-├── sidebars-kruiseagents.js  # Kruise Agents sidebar
-├── docs/                     # Kruise core docs (English, current/unreleased version)
-├── rollouts/                 # Rollouts docs (English)
-├── kruisegame/               # OpenKruiseGame docs (English)
-├── kruiseagents/             # Kruise Agents docs (English)
-├── versioned_docs/           # Snapshot of docs for each released version (v1.5–v1.9)
-├── versioned_sidebars/       # Sidebars for each released version
-├── blog/                     # Blog posts (English)
-├── i18n/zh/                  # Chinese translations
-│   ├── docusaurus-plugin-content-docs/
-│   │   ├── current/          # ZH translation of docs/ (current version)
-│   │   └── version-vX.Y/     # ZH translation of versioned_docs/version-vX.Y/
-│   ├── docusaurus-plugin-content-docs-rollouts/current/
-│   ├── docusaurus-plugin-content-docs-kruisegame/current/
-│   ├── docusaurus-plugin-content-docs-kruiseagents/current/
-│   ├── docusaurus-plugin-content-blog/       # ZH blog translations
-│   ├── docusaurus-theme-classic/             # navbar.json, footer.json
-│   └── code.json                             # UI string translations
-├── src/
-│   ├── pages/                # React pages (index.js, adopters.js, zh/adopters.js)
-│   ├── components/           # React components (HomepageFeatures, LatestRelease, SupportersSection)
-│   ├── css/custom.css        # Custom theme overrides (Infima CSS variables)
-│   └── data/adopters.js      # Adopters list data
-├── static/                   # Static assets (images, CNAME, favicon, verification files)
-├── .github/workflows/        # CI pipeline (build, typo-check, struct-check)
-└── babel.config.js
-```
+## Safeguards
 
-## Documentation Versioning
-
-Versions are managed via `versions.json`. The config (`docusaurus.config.js`) shows only the 3 most recent released versions plus `current` (next/unreleased):
-
-```js
-onlyIncludeVersions: ['current', ...versions.slice(0, 3)]
-```
-
-The "current" version label is auto-computed as the next minor (e.g., if latest is `v1.9`, current shows `v1.10 🚧`).
-
-To cut a new version:
-```bash
-npm run docusaurus docs:version v1.10
-```
-This snapshots `docs/` into `versioned_docs/version-v1.10/` and creates `versioned_sidebars/version-v1.10-sidebars.json`. Then add `"v1.10"` to the top of `versions.json`.
-
-## Internationalization (i18n)
-
-- **Default locale**: `en`
-- **Supported locales**: `en`, `zh`
-- English docs live in the product directories (`docs/`, `rollouts/`, etc.)
-- Chinese docs live under `i18n/zh/docusaurus-plugin-content-docs-*/current/` mirroring the same file paths
-- When editing or adding a doc, **always update both English and Chinese** versions
-- UI strings are translated in `i18n/zh/code.json`
-- Navbar/footer labels: `i18n/zh/docusaurus-theme-classic/navbar.json` and `footer.json`
-
-### Editing docs
-
-When you add or modify a markdown doc:
-1. Edit the English file (e.g., `docs/user-manuals/cloneset.md`)
-2. Update the corresponding Chinese file (e.g., `i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/cloneset.md`)
-3. If adding a new doc, register it in the appropriate sidebar file (`sidebars.js`, `sidebars-rollouts.js`, etc.)
-4. For versioned docs, the same doc exists in `versioned_docs/version-vX.Y/` and `i18n/zh/docusaurus-plugin-content-docs/version-vX.Y/`
-
-## CI Pipeline
-
-The CI workflow (`.github/workflows/documentation.yaml`) runs on PRs and pushes to `master` with three jobs:
-
-### 1. Test Build (`checks`)
-Runs `npm ci && npm run build` on Node 20. Fails if the Docusaurus build fails (broken links, invalid MDX, etc.).
-
-### 2. Typo Check (`typo-check`)
-Runs `.github/workflows/diff.py` (Python 3.12). Compares English and Chinese docs for consistency:
-- **Title count**: headings (h1–h6) must match between EN and ZH (code blocks excluded)
-- **Link count**: all URLs must match between EN and ZH
-- **Highlight count**: `**bold**` markup must match
-- **Inline code count**: `` `code` `` spans must match
-- **Spelling**: English text is checked with `language_tool_python`; TYPOS category issues fail CI
-
-Check modes:
-- **Strict** (fails CI): versioned docs (`versioned_docs/` ↔ `i18n/zh/docusaurus-plugin-content-docs/version-*`)
-- **Advisory** (warnings only): current docs (`docs/`, `rollouts/`, `kruisegame/`, `kruiseagents/` ↔ their ZH `current/` dirs)
-
-False-positive spellings can be added to `.github/workflows/pre_dict.json`.
-
-### 3. Struct Check (`struct-check`)
-Runs `.github/workflows/version_struct_check.py` (Python 3.10 + Go). Extracts all YAML examples from markdown docs, groups them by `apiVersion`, downloads the corresponding Go struct definitions from the OpenKruise/kruise, kruise-game, and rollouts repos, and validates that the YAML fields match the actual Go struct fields.
-
-## Key Configuration Details
-
-### `docusaurus.config.js`
-- `url`: `https://openkruise.io`, `baseUrl`: `/`
-- `trailingSlash: false`
-- `onBrokenLinks: 'warn'` (warnings, not errors)
-- `onBrokenMarkdownLinks: 'warn'`
-- Algolia search config reads `Algolia_API_KEY` and `Algolia_APP_ID` from env (with fallback defaults)
-- `editUrl` functions generate GitHub edit links per locale and product
-- Prism additional languages: `bash`, `diff`, `json`
-
-### Environment Variables
-- `Algolia_API_KEY` / `ALGOLIA_API_KEY` — Algolia search API key
-- `Algolia_APP_ID` / `ALGOLIA_APP_ID` — Algolia application ID
-- `GIT_USER` — GitHub username for deploy
-- `USE_SSH` — Use SSH for deploy
-- `DEPLOYMENT_BRANCH` — Branch to deploy to (default: `gh-pages`)
-
-## Coding Conventions
-
-### Markdown docs
-- Use standard Markdown with Docusaurus features (admonitions, MDX components)
-- YAML examples in fenced code blocks with ` ```yaml ` language tag
-- Include `apiVersion` in YAML examples (checked by struct-check CI)
-- Keep headings, links, bold text, and inline code consistent between EN and ZH
-
-### React components (`src/`)
-- Use `.js`/`.jsx` for components (no TypeScript in src)
-- CSS modules use `.module.css` convention
-- Custom theme overrides go in `src/css/custom.css` using Infima CSS variables
-
-### Sidebar files
-- Explicitly defined (not autogenerated)
-- Categories use `type: 'category'` with `collapsed` and `items`
-- Sub-categories use plain object shorthand: `{ 'Subgroup Name': ['doc-id-1', 'doc-id-2'] }`
-
-## Common Tasks
-
-### Add a new documentation page
-1. Create the English markdown file in the appropriate product directory
-2. Create the Chinese translation in the matching `i18n/zh/` path
-3. Add the doc ID to the sidebar file
-4. Run `npm run build` to verify no broken links
-
-### Update an existing doc
-1. Edit the English file
-2. Sync the Chinese file (same structural changes: headings, links, code blocks)
-3. If the doc is versioned, check whether the change applies to released versions too
-
-### Add a blog post
-1. Create `blog/YYYY-MM-DD-post-name.md` with frontmatter (title, authors, tags, date)
-2. Create the Chinese version in `i18n/zh/docusaurus-plugin-content-blog/`
-3. Register authors in `blog/authors.yml`
-
-## Behavior rules
-
-- Do not edit files under `.docusaurus/` — it is a generated cache
-- Do not edit `versioned_docs/` or `versioned_sidebars/` directly unless backporting a fix to a released version
-- Do not commit `.env` (it is gitignored; only `.env.local` patterns are tracked in `.gitignore`)
-- Do not modify `package-lock.json.back` or `yarn.lock.back` — they are backups
-- Avoid breaking the EN/ZH consistency checks (titles, links, highlights, inline code counts must match)
-- Always commit with sign-off (e.g. `git commit -s`)
-
+- Do not edit `.docusaurus/`, `build/`, backup lockfiles, or generated content.
+- Use npm; update `package-lock.json` only when dependencies change. Never commit credentials or `.env` files.
+- Commit only when asked, using `git commit -s`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,11 @@ npm run build
 
 Before finishing, inspect the changed-file list for missing bilingual counterparts and address warnings introduced by the change. Run relevant `.github/workflows/` checks when changing consistency tooling.
 
+The `struct-check` CI job (`.github/workflows/version_struct_check.py`, Python 3.10 + Go) extracts every YAML example from the docs, groups them by `apiVersion`, downloads the matching Go struct definitions from the OpenKruise `kruise`, `kruise-game`, and `rollouts` repos, and validates that the YAML fields match the actual struct fields.
+
 ## Safeguards
 
 - Do not edit `.docusaurus/`, `build/`, backup lockfiles, or generated content.
+- Do not edit `versioned_docs/` or `versioned_sidebars/` directly unless backporting a fix to a released version.
 - Use npm; update `package-lock.json` only when dependencies change. Never commit credentials or `.env` files.
 - Commit only when asked, using `git commit -s`.

--- a/blog/AGENTS.md
+++ b/blog/AGENTS.md
@@ -1,0 +1,5 @@
+# Blog content
+
+- Keep bilingual post filenames, publication dates, slugs, authors, and tags aligned; translate user-facing titles and summaries.
+- Update `authors.yml` only when author metadata changes.
+- Verify release facts and keep post-specific image references aligned.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,3 @@
+# Kruise current documentation
+
+- Verify that API and Kubernetes examples apply to Kruise core rather than another OpenKruise product.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,14 @@ const lightTheme = themes.github;
 const darkTheme = themes.dracula;
 const versions = require('./versions.json');
 
+const contentExclude = [
+  '**/_*.{js,jsx,ts,tsx,md,mdx}',
+  '**/_*/**',
+  '**/*.test.{js,jsx,ts,tsx}',
+  '**/__tests__/**',
+  '**/AGENTS.md',
+];
+
 function getNextVersionName() {
   const expectedPrefix = 'v1.';
 
@@ -36,6 +44,7 @@ function getNextVersionName() {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
+          exclude: contentExclude,
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: function ({
             locale,
@@ -60,12 +69,16 @@ function getNextVersionName() {
           },
         },
         blog: {
+          exclude: contentExclude,
           blogSidebarTitle: 'All posts',
           blogSidebarCount: 'ALL',
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
             'https://github.com/openkruise/openkruise.io/edit/master/',
+        },
+        pages: {
+          exclude: contentExclude,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -82,6 +95,7 @@ function getNextVersionName() {
         path: 'rollouts',
         routeBasePath: 'rollouts',
         include: ['**/*.{md,mdx}'],
+        exclude: contentExclude,
         sidebarPath: require.resolve('./sidebars-rollouts.js'),
         editUrl: ({locale, docPath}) => {
           if (locale !== 'en') {
@@ -100,6 +114,7 @@ function getNextVersionName() {
         path: 'kruisegame',
         routeBasePath: 'kruisegame',
         include: ['**/*.{md,mdx}'],
+        exclude: contentExclude,
         sidebarPath: require.resolve('./sidebars-kruisegame.js'),
         editUrl: ({locale, docPath}) => {
           if (locale !== 'en') {
@@ -118,6 +133,7 @@ function getNextVersionName() {
         path: 'kruiseagents',
         routeBasePath: 'kruiseagents',
         include: ['**/*.{md,mdx}'],
+        exclude: contentExclude,
         sidebarPath: require.resolve('./sidebars-kruiseagents.js'),
         editUrl: ({locale, docPath}) => {
           if (locale !== 'en') {

--- a/i18n/zh/AGENTS.md
+++ b/i18n/zh/AGENTS.md
@@ -1,0 +1,3 @@
+# Simplified Chinese content
+
+- Treat Chinese files as translations, not independent specifications: compare the English source, use natural Simplified Chinese without adding behavior, and update English when technical meaning changes.

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/cert-manager.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/cert-manager.md
@@ -13,8 +13,14 @@
 
 ## 步骤二：通过 cert-manager 自动管理证书
 
-1. 将 [cert-manager.yaml](https://github.com/openkruise/agents/blob/master/docs/best-practices/cert-manager.yaml) 中的 "*.your.domain.com" 与 "your.domain.com" 替换为你的域名。
-2. 将配置添加到 Kubernetes 集群中：`kubectl apply -f cert-manager.yaml`
+1. 选择合适的示例：
+   - 使用单个域名时，替换
+     [cert-manager.yaml](https://github.com/openkruise/agents/blob/master/docs/best-practices/cert-manager.yaml) 中的
+     `your.domain.com` 与 `*.your.domain.com`。
+   - 使用多个域名时，替换
+     [cert-manager-multi-domain.yaml](https://github.com/openkruise/agents/blob/master/docs/best-practices/cert-manager-multi-domain.yaml)
+     的 `dnsNames` 列表。对于每个原生 E2B 域名，都需要同时包含基础域名与通配符域名。
+2. 将选定的配置添加到 Kubernetes 集群中，例如：`kubectl apply -f cert-manager-multi-domain.yaml`。
 
 ## 步骤三：验证证书状态
 

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/use-self-signed-cert.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/best-practices/use-self-signed-cert.md
@@ -23,14 +23,19 @@ $ bash generate-certificates.sh --help
 Usage: generate-certificates.sh [OPTIONS]
 
 Options:
-  -d, --domain DOMAIN     Specify certificate domain (default: your.domain.com)
+  -d, --domain DOMAIN     Add a base domain; may be specified multiple times
+                          DOMAIN and *.DOMAIN will both be added
   -o, --output DIR        Specify output directory (default: .)
   -D, --days DAYS         Specify certificate validity days (default: 365)
+      --ca-key PATH       Reuse an existing CA private key
+      --ca-cert PATH      Reuse the matching existing CA certificate; it must
+                          be authorized to sign and valid for --days
   -h, --help              Show this help message
 
 Examples:
-  generate-certificates.sh -d myapp.your.domain.com
-  generate-certificates.sh --domain api.your.domain.com --days 730
+  generate-certificates.sh -d example1.com -d example2.com
+  generate-certificates.sh --domain example1.com --domain example2.com --days 730
+  generate-certificates.sh -d example.com --ca-key ca-key.pem --ca-cert ca-cert.pem
 ```
 
 完成证书生成后，您会得到以下文件：
@@ -40,7 +45,12 @@ Examples:
 - ca-fullchain.pem：CA 证书公钥
 - ca-privkey.pem：CA 证书私钥
 
-该脚本会同时生成单域名（your.domain）与泛域名（*.your.domain）证书，兼容原生 E2B 协议与 OpenKruise 定制 E2B 协议。
+对于通过 `--domain` 传入的每个基础域名，脚本都会将该域名及其通配符域名加入证书 SAN。例如，
+`-d example1.com -d example2.com` 生成的证书会覆盖 `example1.com`、`*.example1.com`、`example2.com` 和
+`*.example2.com`，可供同一个 `sandbox-manager` 服务多个原生协议或私有协议 E2B 入口。
+
+默认情况下，每次执行都会创建新的 CA。如果需要使用同一信任根签发新的服务器证书，请同时通过 `--ca-key` 和
+`--ca-cert` 传入已有的 CA 私钥与证书。该 CA 必须在所请求的有效期内保持有效，并具备证书签发权限。
 
 ## 步骤二：安装证书
 

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/api-keys-and-teams.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/api-keys-and-teams.md
@@ -414,6 +414,83 @@ sandbox-manager \
 - 当鉴权关闭（`--e2b-enable-auth=false`）时，上述参数与环境变量都会被忽略，Key 存储后端不会被初始化。
 - 当 `--e2b-key-storage=mysql` 但 DSN 或 pepper 为空时，`sandbox-manager` 会在启动时 fail fast。
 
+### 从 `secret` 迁移到 `mysql`
+
+使用
+[`migrate_secret_keys_to_mysql.py`](https://github.com/openkruise/agents/blob/master/hack/migrate_secret_keys_to_mysql.py)
+可将 `e2b-key-store` Secret 导出为 MySQL DDL 和 upsert 语句。生成的 SQL 会创建 `teams` 与 `team_api_keys`
+表，并迁移 Team 元数据、API Key 元数据、配额及 HMAC-SHA256 Key 哈希；SQL 文件中不会写入明文 API Key。
+缺少 Team 元数据的旧 Key 会归入 `admin` Team。
+
+脚本依赖 Python 3 和 `kubectl`。迁移前请确认当前 Kubernetes context 可以读取源 Secret，并且 MySQL 数据库已经创建，
+可通过 `mysql` 客户端连接。
+
+:::warning 凭证连续性
+生成 SQL 和以 MySQL 模式运行 `sandbox-manager` 时，必须使用完全相同的 `E2B_KEY_HASH_PEPPER`。更换 pepper 会导致
+所有已迁移的 API Key 鉴权失败。同时，`--e2b-admin-key` 必须继续使用迁移前的 admin Key；MySQL 后端初始化时会根据该启动参数
+校准 admin 记录。
+:::
+
+1. 安排维护窗口，在切换验证完成前停止创建和删除 API Key。脚本导出的是一个快照，导出后的变更不会包含在 SQL 中。
+   请备份源 Secret；如果目标数据库不为空，也要先备份数据库。Secret 中包含仅经过 base64 编码的明文凭证，备份必须存放在
+   访问受限的加密位置。
+
+   ```shell
+   umask 077
+   kubectl -n sandbox-system get secret e2b-key-store -o yaml \
+     > /secure/path/e2b-key-store-backup.yaml
+   ```
+
+2. 在 `openkruise/agents` 仓库的 checkout 中先校验所有 Secret 条目，不生成 SQL：
+
+   ```shell
+   python3 hack/migrate_secret_keys_to_mysql.py \
+     --namespace sandbox-system \
+     --dry-run
+   ```
+
+   如果条目格式错误、Secret data key 与 API Key UUID 不一致、原始 Key 重复，或者 Team Name 与 UUID 冲突，校验会直接失败。
+   请先修复源数据再继续；脚本不会跳过无效条目。
+
+3. 使用 MySQL 后端后续将长期使用的 pepper 生成迁移 SQL：
+
+   ```shell
+   export E2B_KEY_HASH_PEPPER='<durable-secret>'
+
+   python3 hack/migrate_secret_keys_to_mysql.py \
+     --namespace sandbox-system \
+     --output /secure/path/e2b_key_migration.sql
+   ```
+
+   默认源 Secret 为 `e2b-key-store`，如名称不同可通过 `--secret-name` 指定。脚本默认使用约定的 admin Team UUID
+   `550e8400-e29b-41d4-a716-446655449999`。`--admin-team-uid` 可以修改导出器写入的 UUID，但当前
+   `sandbox-manager` 启动时会将 admin Team 校准为上述约定 UUID，因此常规切换应保留默认值。`--output -` 可将 SQL
+   写入标准输出，`--quiet` 可关闭成功提示。
+
+4. 检查生成的 SQL，然后将其导入目标数据库：
+
+   ```shell
+   mysql --host=mysql.example.com --user=e2b --password e2b \
+     < /secure/path/e2b_key_migration.sql
+   ```
+
+5. 将 `sandbox-manager` 切换到 MySQL 后端。生成的 SQL 已创建 Schema，因此可以关闭 Schema 自动迁移：
+
+   ```shell
+   export E2B_KEY_STORAGE_DSN='e2b:secretpwd@tcp(mysql.example.com:3306)/e2b?charset=utf8mb4&parseTime=True&loc=Local'
+   export E2B_KEY_HASH_PEPPER='<same-durable-secret-used-for-export>'
+
+   sandbox-manager \
+     --e2b-enable-auth=true \
+     --e2b-admin-key='<same-admin-key-used-before-migration>' \
+     --e2b-key-storage=mysql \
+     --e2b-key-storage-disable-schema-auto-update=true
+   ```
+
+6. 使用原有 admin Key 和有代表性的租户 Key 分别访问 `/teams` 或 `/api-keys`，验证通过后再恢复 Key 的创建和删除。
+   在确认切换成功前请保留原始 `e2b-key-store` Secret。切回 `secret` 只能恢复该 Secret 中的快照；切换后在 MySQL 中创建或
+   删除的 Key 不会自动同步回 Secret。
+
 ### 后端选型建议
 
 | 场景                                           | 推荐后端                                                       |

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/e2b-client.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/e2b-client.md
@@ -18,16 +18,31 @@ OpenKruise Agents 的 sandbox-manager 组件支持两种 E2B 接入协议：原�
 | api.your.domain.com              | your.domain.com/kruise/api              | 
 | \<port\>-\<sid\>.your.domain.com | your.domain.com/kruise/\<sid\>/\<port\> |
 
-## 关于 E2B_DOMAIN 环境变量的重要说明
+## 配置 E2B 域名
 
-**非常重要**：sandbox-manager 的 `E2B_DOMAIN` 环境变量必须与客户端设置相同。
-您可以使用 `kubectl edit deploy -n sandbox-system sandbox-manager` 编辑你的 deployment 修改服务端环境变量。
+基于域名接入的客户端需要配置 `E2B_DOMAIN`。服务端 `sandbox-manager` 支持两种域名模式：
 
-### 如何配置服务端（sandbox-manager）的 E2B_DOMAIN
+- **动态解析（未传入参数时的默认模式）**：当 `--e2b-domain` 为空时，`sandbox-manager` 根据每个请求的 HTTP `Host`
+  推导响应域名。原生协议请求会移除主机名开头的 `api.`，私有协议请求则保留完整主机名。因此，同一个
+  `sandbox-manager` 可以服务多个域名。
+- **静态覆盖**：当 `--e2b-domain` 非空时，服务端会原样返回该值并忽略请求主机名。所有客户端都通过同一个域名访问
+  `sandbox-manager` 时，可以使用此模式。
 
-#### 方法 1：通过 Helm 配置（推荐）
+例如，在动态解析模式下，配置了 `E2B_DOMAIN=example1.com` 和 `E2B_DOMAIN=example2.com` 的客户端可以共用
+同一个 `sandbox-manager`。发往 `api.example1.com` 的请求会得到 `example1.com` 下的 Sandbox 地址，发往
+`api.example2.com` 的请求则会得到 `example2.com` 下的地址。
 
-在通过 Helm 安装或升级 Sandbox Manager 时，您可以使用 `e2b.domain` 参数来设置 `E2B_DOMAIN`：
+:::note
+动态解析使用 HTTP `Host` 请求头，不信任 `X-Forwarded-Host`。请配置各级反向代理，使其保留 `Host`，或将 `Host`
+重写为客户端所使用的公网访问地址。
+:::
+
+### 配置服务端
+
+默认部署清单使用动态解析，不传递 `--e2b-domain`。如果 Helm Chart 或已有 Deployment 设置了域名，请将其清空
+（例如使用 `--set-string e2b.domain=""`），或移除 `--e2b-domain` 参数以启用动态解析。
+
+如果需要在通过 Helm 安装或升级 Sandbox Manager 时保留静态域名，请显式设置 `e2b.domain`：
 
 ```bash
 helm install agents-sandbox-manager openkruise/agents-sandbox-manager \
@@ -37,11 +52,9 @@ helm install agents-sandbox-manager openkruise/agents-sandbox-manager \
   --set ingress.className=<your-ingress-class>
 ```
 
-#### 方法 2：通过手动 Patch 配置
+配置静态覆盖时，该值必须与客户端的 `E2B_DOMAIN` 相同。
 
-您可以在运行 `make deploy-sandbox-manager` 之前通过编辑以下文件来配置服务端的 E2B_DOMAIN：
-
-### 如何配置客户端（E2B SDK）的 E2B_DOMAIN
+### 配置客户端
 
 您可以通过设置环境变量来配置客户端的 E2B_DOMAIN：
 
@@ -55,14 +68,23 @@ export E2B_DOMAIN=your.domain.com
 
 对于 Ingress 网关不使用默认 HTTP 端口（80 或 443）的场景。例如，如果域名是 `your.domain.com:8080`：
 
-- 客户端：设置环境变量 `E2B_DOMAIN=your.domain.com:8080`
-- 服务端：
-    - 在
-      [configuration_patch.yaml](https://github.com/openkruise/agents/blob/master/config/sandbox-manager/configuration_patch.yaml)
-      中，**保留端口**，将 E2B Domain 设置为 `your.domain.com:8080`
-    - 在
-      [ingress_patch.yaml](https://github.com/openkruise/agents/blob/master/config/sandbox-manager/ingress_patch.yaml)
-      中，**不要保留端口**，将 `replace.with.your.domain` 替换为 `your.domain.com`
+- 客户端：设置 `E2B_DOMAIN=your.domain.com:8080`。
+- 服务端使用动态解析时，会自动保留请求主机名中的端口。
+- 服务端使用静态覆盖时，设置 `--e2b-domain=your.domain.com:8080`。
+- Ingress 的主机名规则使用不带端口的 `your.domain.com`。
+
+#### 2. 多域名
+
+如果需要通过多个域名暴露同一个 `sandbox-manager`：
+
+1. 保持 `--e2b-domain` 为空，启用服务端动态解析。
+2. 为每个公网入口配置 DNS 和 Ingress 路由。原生协议使用默认的基于主机名的路由时，需要配置 `api.<domain>` 与
+   `*.<domain>`；使用私有协议时，需要配置基础域名。
+3. 准备覆盖所有入口的证书。[自签名证书](../best-practices/use-self-signed-cert.md)与
+   [cert-manager](../best-practices/cert-manager.md) 指南均提供了多域名示例。
+4. 将每个客户端的 `E2B_DOMAIN` 设置为该客户端实际连接的域名。
+
+此场景不要设置静态 `--e2b-domain`，因为静态值会覆盖所有请求主机名。
 
 ## 如何安装证书
 
@@ -88,7 +110,7 @@ kubectl create secret tls sandbox-manager-tls \
 
 1. 客户端配置环境变量：
     ```shell
-    # sandbox-manager 容器的 E2B_DOMAIN 环境变量应设置为相同值
+    # 如果服务端配置了静态 E2B 域名，其值必须与客户端相同
     export E2B_DOMAIN=your.domain.com
     export E2B_API_KEY=<your-api-key>
     ```
@@ -102,7 +124,7 @@ kubectl create secret tls sandbox-manager-tls \
 
 1. 客户端配置环境变量：
     ```shell
-    # sandbox-manager 容器的 E2B_DOMAIN 环境变量应设置为相同值
+    # 如果服务端配置了静态 E2B 域名，其值必须与客户端相同
     export E2B_DOMAIN=your.domain.com
     export E2B_API_KEY=<your-api-key>
     ```
@@ -114,20 +136,23 @@ kubectl create secret tls sandbox-manager-tls \
 3. 在您的 DNS 提供商处将单个域名 `your.domain.com` 解析到 sandbox-manager 的 ingress 端点
 4. 安装单个域名证书 `your.domain.com`
 
-### 3. 使用 E2B URL 参数实现集群内访问
+### 3. 使用 E2B URL 参数实现集群外访问
 
-> 通过 E2B SDK 原生支持的 URL 参数直接连接集群内的 sandbox-manager，无需域名、证书或私有协议 patch。要求 `e2b >= 2.7.0`。
+> 通过 E2B SDK 原生支持的 URL 参数从集群外直接访问 `sandbox-manager` 和 `sandbox-gateway`，无需通配符 DNS 或
+> 私有协议 patch。要求 `e2b >= 2.7.0`。
 
-1. 确保客户端（agent）和 sandbox-manager 在同一集群中。
-2. 客户端配置环境变量：
+1. 准备两个公网域名，并将其分别路由到对应的 Ingress 端点：
+   - `api.your.domain.com`：路由到 `sandbox-manager` 的控制面域名。`api.` 前缀是固定的，不能替换为其他子域名。
+   - `gateway.your.domain.com`：路由到 `sandbox-gateway` 的数据面域名。该域名可以使用任意子域名，推荐使用
+     `gateway`。
+2. 安装同时覆盖 `api.your.domain.com` 和 `gateway.your.domain.com` 的 TLS 证书。
+3. 配置客户端环境变量：
     ```shell
-    export E2B_API_URL="http://sandbox-manager.sandbox-system.svc.cluster.local:8080"
-    # 如果未安装外置的流量网关 sandbox-gateway，可以将下方 service 替换为 sandbox-manager
-    # 以继续使用 sandbox-manager 内置的流量代理（不推荐）
-    export E2B_SANDBOX_URL="http://sandbox-gateway.sandbox-system.svc.cluster.local:7788"
+    export E2B_API_URL="https://api.your.domain.com"
+    export E2B_SANDBOX_URL="https://gateway.your.domain.com"
     export E2B_API_KEY=<your-api-key>
     ```
-3. 使用 E2B SDK 创建 Sandbox，无需额外 patch：
+4. 使用 E2B SDK 创建 Sandbox，无需额外 patch：
     ```python
     from e2b import Sandbox
 
@@ -137,7 +162,22 @@ kubectl create secret tls sandbox-manager-tls \
     sandbox.kill()
     ```
 
-> ⚠️ **限制说明**：上层库 `e2b-code-interpreter` 和 `e2b-desktop` 的以下扩展功能不读取 `E2B_API_URL` / `E2B_SANDBOX_URL` 环境变量，因此不支持此接入方式：
+:::tip 集群内配置
+当客户端、`sandbox-manager` 和 `sandbox-gateway` 位于同一集群时，可以直接使用 Kubernetes Service 地址，
+好处是无需配置公网 DNS 解析：
+
+```shell
+export E2B_API_URL="http://sandbox-manager.sandbox-system.svc.cluster.local:8080"
+export E2B_SANDBOX_URL="http://sandbox-gateway.sandbox-system.svc.cluster.local:7788"
+export E2B_API_KEY=<your-api-key>
+```
+
+如果未安装外置的 `sandbox-gateway`，可以将 `E2B_SANDBOX_URL` 改为使用 `sandbox-manager`，继续使用其内置
+流量代理，但不推荐这种方式。
+:::
+
+> ⚠️ **限制说明**：上层库 `e2b-code-interpreter` 和 `e2b-desktop` 的以下扩展功能不读取 `E2B_API_URL` /
+> `E2B_SANDBOX_URL` 环境变量，因此不支持这种 URL 参数接入方式：
 >
 > **e2b-code-interpreter：**
 > - `Sandbox.run_code`
@@ -157,7 +197,7 @@ kubectl create secret tls sandbox-manager-tls \
 1. 确保客户端（agent）和 sandbox-manager 在同一集群中。
 2. 客户端配置环境变量：
     ```shell
-    # sandbox-manager 容器的 E2B_DOMAIN 环境变量应设置为相同值
+    # 如果服务端配置了静态 E2B 域名，其值必须与客户端相同
     export E2B_DOMAIN=sandbox-manager.sandbox-system.svc.cluster.local
     export E2B_API_KEY=<your-api-key>
     ```
@@ -171,7 +211,7 @@ kubectl create secret tls sandbox-manager-tls \
 
 1. 客户端配置环境变量：
     ```shell
-    # sandbox-manager 容器的 E2B_DOMAIN 环境变量应设置为相同值
+    # 如果服务端配置了静态 E2B 域名，其值必须与客户端相同
     export E2B_DOMAIN=localhost
     export E2B_API_KEY=<your-api-key>
     ```

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/pause-resume.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/pause-resume.md
@@ -49,7 +49,8 @@ await sbx.betaPause()
 注意事项：
 
 - 对非 `running` 状态的沙箱执行 pause 会返回 `409 Conflict`。
-- 休眠期间沙箱 **不会** 被自动删除——空闲超时计时会在休眠期间被关闭。
+- 休眠沙箱的存活时间与运行态 timeout 分开控制。`sandbox-manager` 默认使用 `forever` 休眠保留策略；如需设置更短的
+  保留窗口，请参考[保留休眠沙箱](#保留休眠沙箱)。
 
 </TabItem>
 <TabItem value="CRD" label="Kubernetes CRD">
@@ -143,6 +144,85 @@ spec:
 </TabItem>
 </Tabs>
 
+## 保留休眠沙箱
+
+`reserve-paused-sandbox-duration` 用于控制一个带 timeout 的 Sandbox 在 **实际执行 pause 转换后** 继续保留多久。
+Sandbox 休眠时，OpenKruise Agents 会按下面的方式重新计算 `spec.shutdownTime`：
+
+```text
+pause 转换执行时间 + reserve-paused-sandbox-duration
+```
+
+该值必须是正数 [Go duration](https://pkg.go.dev/time#ParseDuration)，例如 `30m`、`2h` 或 `168h`。特殊值
+`forever` 表示内置的 **100 年** 保留窗口，并不是真正无限期的 deadline。`0`、负数以及 `1d` 都是非法值
+（`time.ParseDuration` 不支持 `d` 单位）。
+
+该策略只会重新计算已有的 timeout。通过 `never-timeout` 扩展创建的 Sandbox 没有 `shutdownTime`，休眠保留策略不会
+为其创建 deadline。
+
+<Tabs>
+<TabItem value="E2B" label="E2B SDK">
+
+创建时通过 `e2b.agents.kruise.io/reserve-paused-sandbox-duration` metadata 扩展设置持久化保留策略。
+该策略同时适用于自动休眠和后续的手动休眠：
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sbx = Sandbox.create(
+    template="demo",
+    timeout=600,
+    lifecycle={"on_timeout": "pause", "auto_resume": False},
+    metadata={
+        "e2b.agents.kruise.io/reserve-paused-sandbox-duration": "2h",
+    },
+)
+```
+
+手动 pause 时，可以通过 `x-e2b-kruise-reserve-paused-sandbox-duration` 请求头覆盖持久化值。
+当该请求实际执行 running → paused 转换时，成功接受的覆盖值会持久化，供后续 pause 操作继续使用：
+
+```python
+sbx.pause(
+    headers={
+        "x-e2b-kruise-reserve-paused-sandbox-duration": "30m",
+    }
+)
+```
+
+取值优先级为 **pause 请求头 → 已持久化策略 → `forever` 默认值**。创建 metadata 或 pause 请求头包含非法值时，
+`sandbox-manager` 会返回 `400 Bad Request`。由 manager 创建且未显式设置该值的 Sandbox 使用 `forever`，并将其
+持久化到内部注解 `agents.kruise.io/reserve-paused-sandbox-duration`。
+
+</TabItem>
+<TabItem value="CRD" label="Kubernetes CRD">
+
+使用控制器自动休眠时，添加 `agents.kruise.io/reserve-paused-sandbox-duration` 注解，并同时设置
+`spec.pauseTime` 和 `spec.shutdownTime`。该注解会让控制器先执行已经到期的 pause，再把 `shutdownTime` 改为
+pause 转换执行时间加上保留窗口：
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: my-sandbox
+  namespace: default
+  annotations:
+    agents.kruise.io/reserve-paused-sandbox-duration: "2h"
+spec:
+  pauseTime: "2026-05-13T10:00:00Z"
+  shutdownTime: "2026-05-13T10:00:00Z"
+```
+
+直接使用 CRD 的路径不会在注解缺失时应用默认策略：没有该注解，控制器就不会重新计算 `shutdownTime`。
+如果显式存在的注解值非法，控制器会记录错误，并在本次自动休眠中使用 `forever` 对应的 100 年窗口，但不会改写非法注解。
+
+控制器只会在 `spec.pauseTime` 触发自动休眠时解析该注解。直接 patch `spec.paused: true` **不会** 据此计算保留窗口；
+通过 CRD 手动休眠时，请在同一个 patch 中写入期望的绝对时间 `spec.shutdownTime`。
+
+</TabItem>
+</Tabs>
+
 ## 唤醒沙箱
 
 E2B SDK 侧 **推荐** 使用 `Sandbox.connect(...)`——它会隐式地唤醒一个休眠中的沙箱，同时刷新其 timeout。遗留的 `resume` 端点仅出于向后兼容而保留，新代码不应再使用。
@@ -195,6 +275,7 @@ kubectl patch sbx my-sandbox -n default --type=merge \
 | 到 timeout 时自动触发 pause                     | ✅ `lifecycle.on_timeout='pause'` | ❌                                       |
 | 在绝对时间点自动触发 pause                      | ❌                                | ✅ `spec.pauseTime`                      |
 | 自动唤醒（auto-resume）                         | ❌ 暂不支持                        | ❌ 暂不支持                               |
+| 配置进入 paused 后的删除时间                    | ✅ 创建 metadata 或 pause 请求头    | ✅ 自动休眠使用注解；手动休眠写 `spec.shutdownTime` |
 | 唤醒的同时设置 / 刷新 timeout                   | ✅ `Sandbox.connect(id, timeout=...)` | ✅ 同一次 patch 中写 `spec.shutdownTime` / `spec.pauseTime` |
 | 运行态下对 timeout 的只延长（extend-only）保护  | ✅                                | ❌ 用户写入值可缩短                    |
 | 观察 paused / running 状态                      | 通过 SDK 响应                     | `status.phase`（`Paused` / `Running`）   |
@@ -204,6 +285,7 @@ kubectl patch sbx my-sandbox -n default --type=merge \
 ## 注意事项
 
 - **连接会断开。** 休眠时 Pod 被冻结，所有活动连接（WebSocket / PTY / 命令流）都会断开，客户端需要在唤醒后重连。
-- **休眠期间的生命周期。** 休眠中的沙箱不会因为空闲超时而被自动删除，自动删除由 `spec.shutdownTime` 独立控制。
+- **休眠期间的生命周期。** 运行态 timeout 不会在休眠后原样继续倒计时；自动删除由 `spec.shutdownTime` 控制，
+  休眠保留策略可以基于 pause 转换执行时间重新计算它。
 - **旧版 SDK。** 遗留的 `POST /sandboxes/{sandboxID}/resume` 端点仅为旧版 SDK 兼容保留。新代码一律使用 `Sandbox.connect(...)`。
 - **状态保留取决于平台。** 跨休眠/唤醒是否保留内存状态依赖具体的运行时平台。如果你需要显式的内存 + 文件系统快照、并且希望能克隆出全新沙箱，请使用 [快照管理](./checkpoint.md)。

--- a/kruiseagents/AGENTS.md
+++ b/kruiseagents/AGENTS.md
@@ -1,0 +1,4 @@
+# Kruise Agents documentation
+
+- Verify Sandbox API fields, lifecycle states, commands, and configuration keys against Kruise Agents.
+- Keep architecture, manuals, best practices, user cases, and developer guides in this plugin even when they reference other OpenKruise products.

--- a/kruiseagents/best-practices/cert-manager.md
+++ b/kruiseagents/best-practices/cert-manager.md
@@ -15,8 +15,13 @@ the [official documentation](https://cert-manager.io/docs/installation/) for ins
 
 ## Step 2: Automatic Certificate Management with cert-manager
 
-1. Replace "*.your.domain.com" and "your.domain.com" in [cert-manager.yaml](https://github.com/openkruise/agents/blob/master/docs/best-practices/cert-manager.yaml) with your domain.
-2. Add the configuration to the Kubernetes cluster: `kubectl apply -f cert-manager.yaml`
+1. Choose an example:
+   - For one domain, replace `your.domain.com` and `*.your.domain.com` in
+     [cert-manager.yaml](https://github.com/openkruise/agents/blob/master/docs/best-practices/cert-manager.yaml).
+   - For multiple domains, replace the entries under `dnsNames` in
+     [cert-manager-multi-domain.yaml](https://github.com/openkruise/agents/blob/master/docs/best-practices/cert-manager-multi-domain.yaml).
+     Include both the base and wildcard name for every native E2B domain.
+2. Apply the selected configuration, for example: `kubectl apply -f cert-manager-multi-domain.yaml`.
 
 ## Step 3: Verify Certificate Status
 

--- a/kruiseagents/best-practices/use-self-signed-cert.md
+++ b/kruiseagents/best-practices/use-self-signed-cert.md
@@ -25,14 +25,19 @@ $ bash generate-certificates.sh --help
 Usage: generate-certificates.sh [OPTIONS]
 
 Options:
-  -d, --domain DOMAIN     Specify certificate domain (default: your.domain.com)
+  -d, --domain DOMAIN     Add a base domain; may be specified multiple times
+                          DOMAIN and *.DOMAIN will both be added
   -o, --output DIR        Specify output directory (default: .)
   -D, --days DAYS         Specify certificate validity days (default: 365)
+      --ca-key PATH       Reuse an existing CA private key
+      --ca-cert PATH      Reuse the matching existing CA certificate; it must
+                          be authorized to sign and valid for --days
   -h, --help              Show this help message
 
 Examples:
-  generate-certificates.sh -d myapp.your.domain.com
-  generate-certificates.sh --domain api.your.domain.com --days 730
+  generate-certificates.sh -d example1.com -d example2.com
+  generate-certificates.sh --domain example1.com --domain example2.com --days 730
+  generate-certificates.sh -d example.com --ca-key ca-key.pem --ca-cert ca-cert.pem
 ```
 
 After completing certificate generation, you will obtain the following files:
@@ -42,8 +47,14 @@ After completing certificate generation, you will obtain the following files:
 - ca-fullchain.pem: CA certificate public key
 - ca-privkey.pem: CA certificate private key
 
-This script generates both single-domain (your.domain) and wildcard (*.your.domain) certificates, compatible with both
-native E2B protocol and OpenKruise customized E2B protocol.
+For every base domain passed with `--domain`, the script adds both the base domain and its wildcard name to the
+certificate SANs. For example, `-d example1.com -d example2.com` covers `example1.com`, `*.example1.com`,
+`example2.com`, and `*.example2.com`. This supports multiple native and private E2B endpoints served by the same
+`sandbox-manager`.
+
+By default, each run creates a new CA. To issue another server certificate from the same trust root, pass the existing
+CA key and certificate together with `--ca-key` and `--ca-cert`. The CA must be valid for the requested lifetime and
+authorized to sign certificates.
 
 ## Step 2: Install Certificates
 

--- a/kruiseagents/user-manuals/api-keys-and-teams.md
+++ b/kruiseagents/user-manuals/api-keys-and-teams.md
@@ -431,6 +431,88 @@ Notes:
   initialized.
 - If `--e2b-key-storage=mysql` is set but the DSN or pepper is empty, `sandbox-manager` fails fast at startup.
 
+### Migrate from `secret` to `mysql`
+
+Use
+[`migrate_secret_keys_to_mysql.py`](https://github.com/openkruise/agents/blob/master/hack/migrate_secret_keys_to_mysql.py)
+to export the `e2b-key-store` Secret as MySQL DDL and upsert statements. The generated SQL creates the `teams` and
+`team_api_keys` tables and migrates team metadata, API key metadata, quotas, and HMAC-SHA256 key hashes. It never
+writes plaintext API keys to the SQL file. Legacy keys without team metadata are assigned to the `admin` team.
+
+The script requires Python 3 and `kubectl`. Before migration, ensure the current Kubernetes context can read the
+source Secret and that the MySQL database already exists and is reachable with the `mysql` client.
+
+:::warning Credential continuity
+Use exactly the same `E2B_KEY_HASH_PEPPER` when generating the SQL and running `sandbox-manager` in MySQL mode.
+Changing the pepper makes every migrated API key fail authentication. Also keep `--e2b-admin-key` set to the same
+admin key used before migration; MySQL backend initialization reconciles the admin row to this startup value.
+:::
+
+1. Schedule a maintenance window and prevent API key create/delete operations until the cutover is verified. The
+   script exports a snapshot, so changes made after the export are not included. Back up the source Secret and any
+   non-empty target database. The Secret contains plaintext credentials encoded with base64; store its backup in a
+   restricted, encrypted location.
+
+   ```shell
+   umask 077
+   kubectl -n sandbox-system get secret e2b-key-store -o yaml \
+     > /secure/path/e2b-key-store-backup.yaml
+   ```
+
+2. From a checkout of the `openkruise/agents` repository, validate every Secret entry without generating SQL:
+
+   ```shell
+   python3 hack/migrate_secret_keys_to_mysql.py \
+     --namespace sandbox-system \
+     --dry-run
+   ```
+
+   Validation aborts if an entry is malformed, its Secret data key does not match the API key UUID, raw keys are
+   duplicated, or team names and UUIDs conflict. Fix the source data before continuing; the script does not skip
+   invalid entries.
+
+3. Generate the migration SQL with the durable pepper that the MySQL backend will use:
+
+   ```shell
+   export E2B_KEY_HASH_PEPPER='<durable-secret>'
+
+   python3 hack/migrate_secret_keys_to_mysql.py \
+     --namespace sandbox-system \
+     --output /secure/path/e2b_key_migration.sql
+   ```
+
+   The default source Secret is `e2b-key-store`. Use `--secret-name` for a different name. By default, the script
+   uses the well-known admin team UUID `550e8400-e29b-41d4-a716-446655449999`. The `--admin-team-uid` option changes
+   the UUID written by the exporter, but the current `sandbox-manager` reconciles the admin team to the well-known
+   UUID at startup, so keep the default for a normal cutover. `--output -` writes SQL to stdout, and `--quiet`
+   suppresses success messages.
+
+4. Review the generated SQL, then import it into the target database:
+
+   ```shell
+   mysql --host=mysql.example.com --user=e2b --password e2b \
+     < /secure/path/e2b_key_migration.sql
+   ```
+
+5. Switch `sandbox-manager` to the MySQL backend. Because the generated SQL already creates the schema, schema
+   auto-migration can be disabled:
+
+   ```shell
+   export E2B_KEY_STORAGE_DSN='e2b:secretpwd@tcp(mysql.example.com:3306)/e2b?charset=utf8mb4&parseTime=True&loc=Local'
+   export E2B_KEY_HASH_PEPPER='<same-durable-secret-used-for-export>'
+
+   sandbox-manager \
+     --e2b-enable-auth=true \
+     --e2b-admin-key='<same-admin-key-used-before-migration>' \
+     --e2b-key-storage=mysql \
+     --e2b-key-storage-disable-schema-auto-update=true
+   ```
+
+6. Verify both the existing admin key and representative tenant keys against `/teams` or `/api-keys`, then re-enable
+   key mutations. Keep the original `e2b-key-store` Secret until the cutover is accepted. Switching back to `secret`
+   restores only the snapshot in that Secret; keys created or deleted in MySQL after cutover are not synchronized
+   back automatically.
+
 ### Choosing a Backend
 
 | Scenario                                              | Recommended Backend |

--- a/kruiseagents/user-manuals/e2b-client.md
+++ b/kruiseagents/user-manuals/e2b-client.md
@@ -21,16 +21,32 @@ Comparison between private protocol and native protocol:
 | api.your.domain.com              | your.domain.com/kruise/api              | 
 | \<port\>-\<sid\>.your.domain.com | your.domain.com/kruise/\<sid\>/\<port\> |
 
-## Important Notes on E2B_DOMAIN Environment Variable
+## Configure E2B domains
 
-**VERY IMPORTANT**: The `E2B_DOMAIN` environment variable of sandbox-manager must be set to the same as the client.
-You can edit the deployment with `kubectl edit deploy -n sandbox-system sandbox-manager`
+Domain-based client integrations set `E2B_DOMAIN`. On the server, `sandbox-manager` supports two domain modes:
 
-### How to Configure E2B_DOMAIN for Server-side (sandbox-manager)
+- **Dynamic resolution (default when the flag is omitted)**: When `--e2b-domain` is empty, `sandbox-manager` derives
+  the response domain from each request's HTTP `Host`. Native requests remove the leading `api.` from the host, while
+  private-protocol requests preserve the host. This allows one `sandbox-manager` deployment to serve multiple domains.
+- **Static override**: When `--e2b-domain` is non-empty, its value is returned exactly and the request host is ignored.
+  Use this mode when every client accesses `sandbox-manager` through the same domain.
 
-#### Method 1: Via Helm (Recommended)
+For example, with dynamic resolution, clients configured with `E2B_DOMAIN=example1.com` and
+`E2B_DOMAIN=example2.com` can share the same `sandbox-manager`. Requests to `api.example1.com` return Sandbox
+addresses under `example1.com`, while requests to `api.example2.com` return addresses under `example2.com`.
 
-When installing or upgrading the Sandbox Manager via Helm, you can set the `E2B_DOMAIN` using the `e2b.domain` parameter:
+:::note
+Dynamic resolution uses the HTTP `Host` header and does not trust `X-Forwarded-Host`. Configure each reverse proxy to
+preserve or rewrite `Host` to the public authority expected by the client.
+:::
+
+### Configure the server
+
+The default manifests use dynamic resolution and do not pass `--e2b-domain`. If your Helm chart or existing Deployment
+sets a domain, clear it (for example, `--set-string e2b.domain=""`) or remove the `--e2b-domain` argument to enable
+dynamic resolution.
+
+To retain a static domain when installing or upgrading Sandbox Manager with Helm, set `e2b.domain` explicitly:
 
 ```bash
 helm install agents-sandbox-manager openkruise/agents-sandbox-manager \
@@ -40,15 +56,9 @@ helm install agents-sandbox-manager openkruise/agents-sandbox-manager \
   --set ingress.className=<your-ingress-class>
 ```
 
-#### Method 2: Via Manual Patch
+When a static override is configured, it must match the client's `E2B_DOMAIN`.
 
-You can configure the server-side E2B_DOMAIN by editing the following files before running
-`make deploy-sandbox-manager`:
-
-- [configuration_patch.yaml](https://github.com/openkruise/agents/blob/master/config/sandbox-manager/configuration_patch.yaml)
-- [ingress_patch.yaml](https://github.com/openkruise/agents/blob/master/config/sandbox-manager/ingress_patch.yaml)
-
-### How to Configure E2B_DOMAIN for Client-side (E2B SDK)
+### Configure the client
 
 You can configure the client-side E2B_DOMAIN by setting environment variables
 
@@ -63,10 +73,23 @@ export E2B_DOMAIN=your.domain.com
 For scenarios where the Ingress gateway does not use default HTTP ports (80 or 443). For example, if the domain is
 `your.domain.com:8080`:
 
-- Client-side: Set environment variable `E2B_DOMAIN=your.domain.com:8080`
-- Server-side: In [configuration_patch.yaml](https://github.com/openkruise/agents/blob/master/config/sandbox-manager/configuration_patch.yaml), 
-  **keep the port**, set E2B Domain to `your.domain.com:8080`; In [ingress_patch.yaml](https://github.com/openkruise/agents/blob/master/config/sandbox-manager/ingress_patch.yaml),
-  **do not keep the port**, replace `replace.with.your.domain` with `your.domain.com`
+- Client-side: Set `E2B_DOMAIN=your.domain.com:8080`.
+- Dynamic server-side resolution preserves the port from the request host automatically.
+- For a static server-side override, set `--e2b-domain=your.domain.com:8080`.
+- In Ingress host rules, use `your.domain.com` without the port.
+
+#### 2. Multiple domains
+
+To expose one `sandbox-manager` through multiple domains:
+
+1. Enable dynamic server-side resolution by leaving `--e2b-domain` empty.
+2. Configure DNS and Ingress routing for every public endpoint. Native protocol deployments using the default
+   hostname-based routing need `api.<domain>` and `*.<domain>`; private protocol deployments need the base domain.
+3. Provision a certificate that covers every endpoint. The [self-signed certificate](../best-practices/use-self-signed-cert.md)
+   and [cert-manager](../best-practices/cert-manager.md) guides include multi-domain examples.
+4. Set each client's `E2B_DOMAIN` to the domain through which that client connects.
+
+Do not configure a static `--e2b-domain` in this setup, because a static value overrides every request host.
 
 ## How to install a certificate
 
@@ -95,7 +118,7 @@ kubectl create secret tls sandbox-manager-tls \
 
 1. Client configuration environment variables:
     ```shell
-    # The E2B_DOMAIN env of sandbox-manager container should be set to the same
+    # A static server-side E2B domain, if configured, must use the same value
     export E2B_DOMAIN=your.domain.com
     export E2B_API_KEY=<your-api-key>
     ```
@@ -109,7 +132,7 @@ kubectl create secret tls sandbox-manager-tls \
 
 1. Client configuration environment variables:
     ```shell
-    # The E2B_DOMAIN env of sandbox-manager container should be set to the same
+    # A static server-side E2B domain, if configured, must use the same value
     export E2B_DOMAIN=your.domain.com
     export E2B_API_KEY=<your-api-key>
     ```
@@ -121,20 +144,24 @@ kubectl create secret tls sandbox-manager-tls \
 3. Resolve single domain `your.domain.com` to sandbox-manager ingress endpoint with your DNS provider
 4. Install single domain certificate `your.domain.com`
 
-### 3. In-cluster access using E2B URL parameters
+### 3. External access using E2B URL parameters
 
-> Connect to sandbox-manager within the cluster using E2B SDK's native URL parameters — no domain, certificate, or private protocol patch required. Requires `e2b >= 2.7.0`.
+> Use the E2B SDK's native URL parameters to access `sandbox-manager` and `sandbox-gateway` from outside the cluster,
+> without wildcard DNS or a private protocol patch. Requires `e2b >= 2.7.0`.
 
-1. Ensure the client (agent) and sandbox-manager are in the same cluster.
-2. Client configuration environment variables:
+1. Prepare two public hostnames and route them to the corresponding Ingress endpoints:
+   - `api.your.domain.com`: Control-plane hostname routed to `sandbox-manager`. The `api.` prefix is required and cannot
+     be replaced with another subdomain.
+   - `gateway.your.domain.com`: Data-plane hostname routed to `sandbox-gateway`. This hostname may use any subdomain;
+     `gateway` is recommended.
+2. Install a TLS certificate that covers both `api.your.domain.com` and `gateway.your.domain.com`.
+3. Configure the client environment variables:
     ```shell
-    export E2B_API_URL="http://sandbox-manager.sandbox-system.svc.cluster.local:8080"
-    # If the external traffic gateway sandbox-gateway is not installed, you can replace the service below with sandbox-manager
-    # to continue using sandbox-manager's built-in traffic proxy (not recommended)
-    export E2B_SANDBOX_URL="http://sandbox-gateway.sandbox-system.svc.cluster.local:7788"
+    export E2B_API_URL="https://api.your.domain.com"
+    export E2B_SANDBOX_URL="https://gateway.your.domain.com"
     export E2B_API_KEY=<your-api-key>
     ```
-3. Create a Sandbox using the E2B SDK — no additional patching required:
+4. Create a Sandbox using the E2B SDK without additional patching:
     ```python
     from e2b import Sandbox
 
@@ -144,7 +171,23 @@ kubectl create secret tls sandbox-manager-tls \
     sandbox.kill()
     ```
 
-> ⚠️ **Limitation**: The following extended features in the upper-level libraries `e2b-code-interpreter` and `e2b-desktop` do not read the `E2B_API_URL` / `E2B_SANDBOX_URL` environment variables, and therefore do not support this access method:
+:::tip In-cluster configuration
+When the client, `sandbox-manager`, and `sandbox-gateway` are in the same cluster, use their Kubernetes Service URLs
+directly. This avoids public DNS configuration:
+
+```shell
+export E2B_API_URL="http://sandbox-manager.sandbox-system.svc.cluster.local:8080"
+export E2B_SANDBOX_URL="http://sandbox-gateway.sandbox-system.svc.cluster.local:7788"
+export E2B_API_KEY=<your-api-key>
+```
+
+If the external `sandbox-gateway` is not installed, `E2B_SANDBOX_URL` can use `sandbox-manager` instead to continue
+using its built-in traffic proxy, although this is not recommended.
+:::
+
+> ⚠️ **Limitation**: The following extended features in the upper-level libraries `e2b-code-interpreter` and
+> `e2b-desktop` do not read the `E2B_API_URL` / `E2B_SANDBOX_URL` environment variables, and therefore do not support
+> this URL-parameter access method:
 >
 > **e2b-code-interpreter:**
 > - `Sandbox.run_code`
@@ -165,7 +208,7 @@ kubectl create secret tls sandbox-manager-tls \
 1. Ensure client(agent) and sandbox-manager are in the same cluster.
 2. Client configuration environment variables:
     ```shell
-    # The E2B_DOMAIN env of sandbox-manager container should be set to the same
+    # A static server-side E2B domain, if configured, must use the same value
     export E2B_DOMAIN=sandbox-manager.sandbox-system.svc.cluster.local
     export E2B_API_KEY=<your-api-key>
     ```
@@ -179,7 +222,7 @@ kubectl create secret tls sandbox-manager-tls \
 
 1. Client configuration environment variables:
     ```shell
-    # The E2B_DOMAIN env of sandbox-manager container should be set to the same
+    # A static server-side E2B domain, if configured, must use the same value
     export E2B_DOMAIN=localhost
     export E2B_API_KEY=<your-api-key>
     ```
@@ -192,4 +235,3 @@ kubectl create secret tls sandbox-manager-tls \
     from kruise_agents.patch_e2b import patch_e2b
     patch_e2b(https=False)
     ```
-

--- a/kruiseagents/user-manuals/pause-resume.md
+++ b/kruiseagents/user-manuals/pause-resume.md
@@ -62,7 +62,9 @@ await sbx.betaPause()
 Notes:
 
 - Pausing a sandbox that is not in `running` state returns `409 Conflict`.
-- Paused sandboxes are kept indefinitely — the auto-shutdown timer is disabled while paused.
+- The lifetime of a paused sandbox is controlled separately from its running timeout. `sandbox-manager` uses the
+  `forever` paused-retention policy by default; you can configure a shorter window as described in
+  [Retaining a Paused Sandbox](#retaining-a-paused-sandbox).
 
 </TabItem>
 <TabItem value="CRD" label="Kubernetes CRD">
@@ -164,6 +166,91 @@ spec:
 </TabItem>
 </Tabs>
 
+## Retaining a Paused Sandbox
+
+`reserve-paused-sandbox-duration` controls how long a timed Sandbox is retained **after its pause transition is
+applied**. When the Sandbox pauses, OpenKruise Agents recalculates `spec.shutdownTime` as:
+
+```text
+pause transition time + reserve-paused-sandbox-duration
+```
+
+The value must be a positive [Go duration](https://pkg.go.dev/time#ParseDuration), such as `30m`, `2h`, or `168h`.
+The special value `forever` selects the built-in **100-year** retention window; it does not create a truly infinite
+deadline. Values such as `0`, negative durations, and `1d` are invalid (`time.ParseDuration` does not support a `d`
+unit).
+
+This policy only recalculates an existing timeout. A Sandbox created with the `never-timeout` extension has no
+`shutdownTime`, so paused retention does not introduce one.
+
+<Tabs>
+<TabItem value="E2B" label="E2B SDK">
+
+Set the persisted retention policy at creation time with the
+`e2b.agents.kruise.io/reserve-paused-sandbox-duration` metadata extension. It applies to auto-pause and to later
+manual pauses:
+
+```python
+from e2b_code_interpreter import Sandbox
+
+sbx = Sandbox.create(
+    template="demo",
+    timeout=600,
+    lifecycle={"on_timeout": "pause", "auto_resume": False},
+    metadata={
+        "e2b.agents.kruise.io/reserve-paused-sandbox-duration": "2h",
+    },
+)
+```
+
+To override the persisted value for a manual pause, pass the
+`x-e2b-kruise-reserve-paused-sandbox-duration` request header. The accepted override is persisted for subsequent
+pause operations when that request performs the running-to-paused transition:
+
+```python
+sbx.pause(
+    headers={
+        "x-e2b-kruise-reserve-paused-sandbox-duration": "30m",
+    }
+)
+```
+
+The resolution order is **pause request header → persisted policy → `forever` default**. If the creation metadata
+or pause header contains an invalid value, `sandbox-manager` returns `400 Bad Request`. Manager-created Sandboxes
+without an explicit value use `forever`, which is persisted as the internal
+`agents.kruise.io/reserve-paused-sandbox-duration` annotation.
+
+</TabItem>
+<TabItem value="CRD" label="Kubernetes CRD">
+
+For controller-driven auto-pause, add the `agents.kruise.io/reserve-paused-sandbox-duration` annotation and set both
+`spec.pauseTime` and `spec.shutdownTime`. The annotation tells the controller to let the due pause run before
+deletion and then replace `shutdownTime` with the pause transition time plus the retention window:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: my-sandbox
+  namespace: default
+  annotations:
+    agents.kruise.io/reserve-paused-sandbox-duration: "2h"
+spec:
+  pauseTime: "2026-05-13T10:00:00Z"
+  shutdownTime: "2026-05-13T10:00:00Z"
+```
+
+The direct CRD path intentionally has no default-when-absent policy: without the annotation, the controller does not
+recalculate `shutdownTime`. If an explicitly present annotation is invalid, the controller logs the error and uses
+the `forever` 100-year window for that auto-pause without rewriting the invalid annotation.
+
+The annotation is evaluated when `spec.pauseTime` triggers auto-pause. It does **not** calculate a retention window
+for a direct `spec.paused: true` patch; for a manual CRD pause, write the desired absolute `spec.shutdownTime` in the
+same patch.
+
+</TabItem>
+</Tabs>
+
 ## Resuming a Sandbox
 
 The recommended interface on the E2B SDK side is `Sandbox.connect(...)` — it implicitly resumes a paused sandbox and
@@ -222,6 +309,7 @@ kubectl patch sbx my-sandbox -n default --type=merge \
 | Auto-pause when the timeout expires                                  | ✅ `lifecycle.on_timeout='pause'` | ❌                                |
 | Auto-pause at a specific absolute time                               | ❌                             | ✅ `spec.pauseTime`                   |
 | Auto-resume a paused sandbox                                         | ❌ not yet supported           | ❌ not yet supported                  |
+| Configure deletion after entering paused                            | ✅ creation metadata or pause header | ✅ annotation for auto-pause; write `spec.shutdownTime` for a manual pause |
 | Set / refresh the sandbox timeout together with resume               | ✅ `Sandbox.connect(id, timeout=...)` | ✅ write `spec.shutdownTime` / `spec.pauseTime` in the same patch |
 | Extend-only guard on timeout refresh while running                   | ✅                             | ❌ user-written value may shorten    |
 | Observe paused/running state                                         | via SDK response              | `status.phase` (`Paused` / `Running`)|
@@ -233,8 +321,8 @@ declarative / GitOps control over the paused/running bit plus absolute schedulin
 
 - **Connection drop.** The Pod is frozen on pause; all active streams (WebSocket / PTY / command streams) disconnect.
   Clients must reconnect after resume.
-- **Timeout during pause.** Paused sandboxes are not auto-deleted by the idle timeout. Auto-delete is controlled
-  separately by `spec.shutdownTime`.
+- **Timeout during pause.** The running timeout does not continue counting down unchanged after pause. Auto-delete is
+  controlled by `spec.shutdownTime`, which paused retention can recalculate from the pause transition time.
 - **Old SDKs.** The legacy `POST /sandboxes/{sandboxID}/resume` endpoint is kept for old SDK compatibility only. New
   code should always use `Sandbox.connect(...)`.
 - **State-preservation caveats.** Whether memory is preserved across pause/resume depends on the runtime platform.

--- a/kruisegame/AGENTS.md
+++ b/kruisegame/AGENTS.md
@@ -1,0 +1,4 @@
+# OpenKruiseGame documentation
+
+- Verify OpenKruiseGame resource names, API groups, workload terminology, and example fields against this product.
+- `blog-video/` belongs to this documentation plugin, not the site-wide `blog/`.

--- a/rollouts/AGENTS.md
+++ b/rollouts/AGENTS.md
@@ -1,0 +1,3 @@
+# Kruise Rollouts documentation
+
+- Verify Rollouts-specific API groups, strategies, traffic-routing behavior, provider names, and upstream references; do not infer them from Kruise core.

--- a/src/pages/AGENTS.md
+++ b/src/pages/AGENTS.md
@@ -1,0 +1,5 @@
+# Standalone Markdown pages
+
+- Markdown and MDX here use file-based routing rather than a documentation plugin or sidebar.
+- Keep product manuals in `docs/`, `rollouts/`, `kruisegame/`, or `kruiseagents/` so the correct plugin owns them.
+- These rules do not apply to React page implementation.

--- a/versioned_docs/AGENTS.md
+++ b/versioned_docs/AGENTS.md
@@ -1,0 +1,4 @@
+# Released Kruise documentation
+
+- Keep each explicit backport within that release's APIs, defaults, commands, and available features.
+- If an approved backport changes paths or document IDs, update the matching `versioned_sidebars/` file and verify that version's links.


### PR DESCRIPTION
## Summary

- Refine repository-wide and section-specific `AGENTS.md` guidance, including documentation boundaries, bilingual authoring rules, versioning, validation, and safeguards.
- Configure Docusaurus to exclude repository guidance and generated/tooling files from documentation processing.
- Document dynamic E2B domain resolution, static overrides, ports, and multi-domain DNS and Ingress requirements in English and Simplified Chinese.
- Add external E2B URL-parameter access with separate control-plane and gateway domains, plus the DNS-free in-cluster configuration.
- Update self-signed certificate and cert-manager guidance for multi-domain SANs and CA reuse.
- Document the `secret`-to-MySQL API key migration workflow, including validation, backup, SQL import, credential continuity, cutover verification, and rollback boundaries.
- Document paused Sandbox retention for E2B and direct CRD workflows, including accepted durations, the 100-year `forever` default, metadata/header/annotation configuration, timeout recalculation, and `never-timeout` behavior.

## Why

The documentation website needs durable, boundary-specific authoring instructions while keeping those instruction files out of generated site content. Kruise Agents also needs user-facing guidance for request-derived E2B domains, a safe operational workflow for the API key migration utility, and clear lifecycle semantics for retaining timed Sandboxes after pause.

## User impact

- Contributors get clearer repository and section-level documentation contracts.
- A single `sandbox-manager` deployment can be documented and configured for multiple public domains without a static server-side domain override.
- Users can avoid wildcard DNS by configuring `E2B_API_URL` and `E2B_SANDBOX_URL`, and in-cluster clients can use Kubernetes Service addresses without public DNS.
- Operators can migrate existing `e2b-key-store` credentials to MySQL while preserving keys, teams, quotas, and authentication continuity.
- Application developers and cluster operators can configure when a paused Sandbox is deleted without confusing running timeout, auto-pause scheduling, and paused-retention deadlines.

## Validation

- `git diff --check upstream/master...HEAD`
- `npm run build`

The Docusaurus build completed for both English and Chinese. It reported only existing repository warnings about blog truncation markers, links, anchors, Chinese plural forms, and the GitHub release lookup fallback.

Related implementations:

- https://github.com/openkruise/agents/pull/649
- https://github.com/openkruise/agents/pull/309
- https://github.com/openkruise/agents/pull/566
