### PR TITLE
docs(kruiseagents): add storage management docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current.json
@@ -11,6 +11,10 @@
     "message": "用户手册",
     "description": "The label for category 'User Manuals' in sidebar 'kruiseagents'"
   },
+  "sidebar.kruiseagents.category.Storage Management": {
+    "message": "存储管理",
+    "description": "The label for category 'Storage Management' in sidebar 'kruiseagents'"
+  },
   "sidebar.kruiseagents.category.Best Practices": {
     "message": "最佳实践",
     "description": "The label for category 'Best Practices' in sidebar 'kruiseagents'"

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/ondemand-volume-mount.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/ondemand-volume-mount.md
@@ -1,0 +1,162 @@
+# On-Demand Volume Mounting
+
+本文介绍如何在申请沙箱时动态挂载已有的 Persistent Volume（PV）。这适用于在多个沙箱之间共享存储，或在不为 `SandboxSet` 模板定义存储的情况下挂载已有数据卷。
+
+## 概述
+
+按需卷挂载允许你在申请沙箱时声明一个或多个 PV 挂载，而不是通过 `volumeClaimTemplates` 为每个沙箱单独申请 PVC。挂载操作由注入到沙箱 Pod 中的 `agent-runtime` 和 CSI Sidecar 完成。
+
+主要特点：
+
+- 申请前 PV 必须已存在于集群中。
+- 同一个 PV 可以挂载到多个沙箱中（例如共享数据集或模型缓存）。
+- 可以通过 E2B SDK 或 `SandboxClaim` CRD 两种方式请求挂载。
+
+## 前提条件
+
+1. 提供沙箱的 `SandboxSet` 必须启用 `csi` 和 `agent-runtime` 运行时。运行时注入的详细说明请参考 [Runtime Injection](./runtime-injection.md)。
+2. 集群中必须已存在一个或多个 PV，并且沙箱所在节点可以访问这些 PV。
+3. 如果你的 CSI 驱动需要凭证，请提前创建对应的 Secret 并在 PV 中引用。
+
+## 在 SandboxSet 中开启挂载能力
+
+在 `SandboxSet` 的 `spec.runtimes` 中添加 `csi` 和 `agent-runtime`。框架会自动为从该模板创建的每个沙箱注入所需的 CSI Sidecar 和 `agent-runtime`。
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: shared-storage-template
+  namespace: default
+spec:
+  replicas: 3
+  runtimes:
+    - name: csi            # 开启动态卷挂载能力
+    - name: agent-runtime  # 挂载编排所需
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: ubuntu:latest
+          command: ["sleep", "infinity"]
+```
+
+## 准备 PersistentVolume
+
+创建一个由你的存储系统支撑的 PV 对象。以下示例使用通用 CSI 驱动；请将 `driver`、`volumeHandle` 和 `volumeAttributes` 替换为你的 CSI 提供商对应的实际值。
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: shared-pv
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 50Gi
+  csi:
+    driver: csi-driver.example.com
+    volumeHandle: shared-pv
+    volumeAttributes:
+      server: <STORAGE_SERVER_ADDRESS>
+      share: <STORAGE_SHARE_NAME>
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  volumeMode: Filesystem
+```
+
+> 请将 CSI 驱动名称和 `volumeAttributes` 替换为你的存储后端实际要求的值。如果 CSI 驱动需要凭证，请按照该驱动的文档进行配置。
+
+## 申请时挂载卷
+
+你可以选择在申请沙箱时通过 E2B SDK 或 `SandboxClaim` 请求挂载。
+
+### 通过 E2B SDK 挂载
+
+请使用 `e2b.agents.kruise.io/csi-volume-config` 扩展，并以 JSON 数组格式声明一个或多个卷挂载。
+
+```python
+import json
+from e2b_code_interpreter import Sandbox
+
+csi_config = json.dumps([
+    {"pvName": "shared-pv-1", "mountPath": "/data1"},
+    {"pvName": "shared-pv-2", "mountPath": "/data2", "subPath": "sub/dir", "readOnly": True}
+])
+
+sbx = Sandbox.create(template="shared-storage-template", timeout=300, metadata={
+    "e2b.agents.kruise.io/csi-volume-config": csi_config
+})
+```
+
+| 字段 | 类型 | 说明 | 是否必填 |
+| --- | --- | --- | --- |
+| `pvName` | String | 已存在 PV 的名称 | 是 |
+| `mountPath` | String | 容器内挂载目标路径 | 是 |
+| `subPath` | String | 持久卷内的子路径 | 否 |
+| `readOnly` | Boolean | 是否以只读方式挂载 | 否 |
+
+> 挂载目标路径必须是一个空目录，否则挂载将失败。
+
+### 通过 SandboxClaim 挂载
+
+在 `SandboxClaim` 中声明 `dynamicVolumesMount` 字段：
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: shared-storage-claim
+  namespace: default
+spec:
+  templateName: shared-storage-template
+  replicas: 1
+  claimTimeout: 5m
+  dynamicVolumesMount:
+    - pvName: "shared-pv-1"
+      mountPath: "/data1"
+    - pvName: "shared-pv-2"
+      mountPath: "/data2"
+      subPath: "sub/dir"
+      readOnly: true
+```
+
+字段说明：
+
+| 字段 | 说明 | 是否必填 |
+| --- | --- | --- |
+| `pvName` | 已存在 PV 的名称 | 是 |
+| `mountPath` | 容器内挂载目标路径 | 是 |
+| `subPath` | 持久卷内的子路径 | 否 |
+| `readOnly` | 是否以只读方式挂载 | 否 |
+
+## 验证挂载结果
+
+当 `SandboxClaim` 进入 `Completed` 阶段后，列出该声明分配出的沙箱：
+
+```bash
+kubectl get sandbox -n default -l agents.kruise.io/claim-name=shared-storage-claim
+```
+
+预期输出：
+
+```text
+NAME                          STATUS    AGE
+shared-storage-template-xxx   Running   22h
+```
+
+在沙箱 Pod 内执行命令验证挂载：
+
+```bash
+kubectl exec -it <POD_NAME> -- df -h /data1
+```
+
+你应该能在请求的路径下看到已挂载的卷。
+
+## 注意事项
+
+- 按需卷挂载依赖 `agent-runtime` 和 CSI Sidecar，相比不带额外挂载的申请，会在一定程度上影响沙箱交付速度。
+- 挂载目标目录必须存在于容器镜像中且为空，否则 CSI 挂载将失败。
+- 如果指定了 `subPath`，子目录不会自动在存储后端创建。请在挂载前确保该目录已存在，或使用会自动创建缺失目录的存储驱动。
+- 该功能目前支持从预热池申请、无库存时新建以及原地镜像升级后的沙箱。通过 Checkpoint 恢复沙箱时，挂载不会被恢复。

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/sandbox-claim.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/sandbox-claim.md
@@ -311,22 +311,7 @@ spec:
 
 > 以下扩展字段为 OpenKruise Agents 扩展字段，不会作为元数据添加到 Sandbox 资源上。
 
-**单卷挂载：**
-
-```python
-from e2b_code_interpreter import Sandbox
-
-sbx = Sandbox.create(template="some-template", timeout=300, metadata={
-    "e2b.agents.kruise.io/csi-volume-name": "oss-pv-test",
-    "e2b.agents.kruise.io/csi-mount-point": "/data",
-    # 可选：指定持久化卷中的子路径
-    "e2b.agents.kruise.io/csi-subpath": "sub/dir"
-})
-```
-
-**多卷挂载：**
-
-如果需要同时挂载多个卷，可以使用 `e2b.agents.kruise.io/csi-volume-config` 扩展字段，传入 JSON 数组：
+请使用 `e2b.agents.kruise.io/csi-volume-config` 扩展字段，并以 JSON 数组格式声明一个或多个卷挂载：
 
 ```python
 import json
@@ -344,12 +329,12 @@ sbx = Sandbox.create(template="some-template", timeout=300, metadata={
 
 参数说明：
 
-| 扩展字段                                     | 说明                   | 是否必填    |
-|------------------------------------------|----------------------|---------|
-| `e2b.agents.kruise.io/csi-volume-name`   | 持久化卷名称               | 是（单卷挂载） |
-| `e2b.agents.kruise.io/csi-mount-point`   | 容器内挂载目标路径            | 是（单卷挂载） |
-| `e2b.agents.kruise.io/csi-subpath`       | 持久化卷中的子路径            | 否       |
-| `e2b.agents.kruise.io/csi-volume-config` | JSON 数组格式的挂载配置（多卷挂载） | 是（多卷挂载） |
+| 字段 | 说明 | 是否必填 |
+| --- | --- | --- |
+| `pvName` | 持久化卷名称 | 是 |
+| `mountPath` | 容器内挂载目标路径 | 是 |
+| `subPath` | 持久化卷中的子路径 | 否 |
+| `readOnly` | 是否以只读方式挂载 | 否 |
 
   </TabItem>
   <TabItem value="SandboxClaim" label="SandboxClaim">

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/volume-claim-template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/volume-claim-template.md
@@ -1,0 +1,187 @@
+# Volume Claim Templates
+
+本文介绍如何在 `SandboxSet` 中使用 `volumeClaimTemplates`，为 OpenKruise Agents 沙箱提供持久化存储。
+
+## 沙箱存储的作用
+
+默认情况下，容器是临时的，沙箱内部生成或修改的任何数据都会在底层 Pod 终止后丢失。
+
+在 `SandboxSet` API 中引入 `volumeClaimTemplates` 可以解决这一问题：它允许每个沙箱实例动态申请自己的 Persistent Volume Claim（PVC）。借助与 Kubernetes StatefulSet 相同的语义，你只需定义一次存储模板，OpenKruise Agents 就会自动为从该模板生成的每个沙箱创建、挂载并管理独立的存储卷。
+
+常见使用场景包括：
+
+- **缓存依赖**：保存已下载的软件包（例如 `node_modules` 或 pip 缓存），在多次 Agent 运行之间复用，加快执行速度。
+- **保留状态**：持久化日志、构建产物或与特定沙箱会话绑定的内部 Agent 数据库。
+- **带状态的预热池**：为 `SandboxSet` 预热池挂载持久卷，使沙箱在启动后即可执行重 I/O 操作，无需等待首次存储分配。
+
+## 工作原理
+
+1. 在 `SandboxSet` 中定义 `volumeClaimTemplates` 列表。
+2. 当 `SandboxSet` 控制器创建新的沙箱时，卷声明模板会自动透传到各个 `Sandbox` 自定义资源。
+3. 控制器随后申请对应的 PVC，并将其合并到底层 Pod 规格中，挂载到容器内部。
+4. 当沙箱 Pod 被重建（例如由于节点驱逐或滚动更新）时，同一个 PVC 会被重新挂载到新的 Pod 上，从而保留数据。
+
+## 创建带卷声明的沙箱集
+
+要使用持久化存储，需要在 `SandboxSet` 规格中添加 `volumeClaimTemplates` 数组，并在容器的 `volumeMounts` 中引用该声明名称。
+
+以下示例假设集群中已存在名为 `standard` 的 StorageClass。如果你的集群没有提供默认 StorageClass，请先创建一个，或将 `storageClassName` 替换为可用的存储类。
+
+创建文件 `sandboxset-with-volume.yaml`：
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: stateful-sandboxset
+  namespace: default
+spec:
+  replicas: 3
+  # 1. 在此处定义动态卷配置
+  volumeClaimTemplates:
+  - metadata:
+      name: agent-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: standard
+      resources:
+        requests:
+          storage: 1Gi
+  # 2. 在容器中引用卷声明的准确名称
+  template:
+    spec:
+      containers:
+      - name: sandbox-agent
+        image: ubuntu:latest
+        command: ["sleep", "infinity"]
+        volumeMounts:
+        - name: agent-data
+          mountPath: /data
+```
+
+将模板应用到 Kubernetes 集群：
+
+```bash
+kubectl apply -f sandboxset-with-volume.yaml
+```
+
+等待预热池就绪：
+
+```bash
+kubectl get sbs stateful-sandboxset
+```
+
+预期输出：
+
+```text
+NAME                  REPLICAS   AVAILABLE   UPDATEREVISION   AGE
+stateful-sandboxset   3          3           xxxxxxxx         92s
+```
+
+## 通过 SandboxClaim 申请沙箱
+
+预热池就绪后，你可以通过创建 `SandboxClaim` 来申请一个实际的沙箱实例。
+
+创建文件 `sandbox-claim.yaml`：
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: my-stateful-sandbox
+  namespace: default
+spec:
+  templateName: stateful-sandboxset
+```
+
+应用该声明：
+
+```bash
+kubectl apply -f sandbox-claim.yaml
+```
+
+等待申请完成：
+
+```bash
+kubectl get sbc my-stateful-sandbox
+```
+
+预期输出：
+
+```text
+NAME                    PHASE       TEMPLATE              DESIRED   CLAIMED   AGE
+my-stateful-sandbox     Completed   stateful-sandboxset   1         1         41s
+```
+
+## 验证自动分配的存储
+
+当你应用 `SandboxClaim` 后，`SandboxSet` 控制器会自动处理 `volumeClaimTemplates` 定义，创建专属的 PVC，并将其挂载到沙箱 Pod 上。
+
+列出 PVC 以确认卷已创建。PVC 名称由声明名和沙箱 Pod 名组合而成：
+
+```bash
+kubectl get pvc
+```
+
+你应该能看到一个形如 `agent-data-<sandbox-pod-name>` 的已绑定 PVC。
+
+如果进入沙箱容器内部，可以验证卷已正确挂载到 `/data` 目录：
+
+```bash
+kubectl exec -it <sandbox-pod-name> -- df -h /data
+```
+
+## 验证数据持久化
+
+为了验证数据持久化，可以删除底层 Pod 来模拟崩溃或驱逐，然后确认控制器重新创建 Pod 后数据仍然保留。
+
+### 1. 向持久卷写入数据
+
+在运行中的沙箱容器内执行命令，在挂载的 `/data` 目录下创建一个文件：
+
+```bash
+kubectl exec -it <sandbox-pod-name> -- sh -c "echo 'This data will survive a pod crash!' > /data/evidence.txt"
+```
+
+### 2. 确认数据存在
+
+读取文件以确保写入成功：
+
+```bash
+kubectl exec -it <sandbox-pod-name> -- cat /data/evidence.txt
+```
+
+### 3. 删除 Pod 模拟故障
+
+由于沙箱由 `SandboxSet` 控制器管理，直接删除 Pod 即可模拟意外故障。
+
+```bash
+kubectl delete pod <sandbox-pod-name>
+```
+
+### 4. 等待控制器重建沙箱
+
+`SandboxSet` 控制器会检测到 Pod 缺失并自动重建。由于 `volumeClaimTemplates` 采用 StatefulSet 类似的语义，控制器会将同一个 PVC 重新挂载到新的 Pod。
+
+观察 Pod 直到新的 Pod 进入运行状态：
+
+```bash
+kubectl get pods -w
+```
+
+### 5. 确认数据仍然保留
+
+当新的替代 Pod 处于 `Running` 状态后，进入容器并再次读取文件：
+
+```bash
+kubectl exec -it <new-sandbox-pod-name> -- cat /data/evidence.txt
+```
+
+你应该能在终端中看到文本 `This data will survive a pod crash!`。
+
+## 注意事项
+
+- `volumeClaimTemplates` 字段位于 `SandboxSet` spec 中，与 `template` 同级，而不是嵌套在 `template.spec` 内部。
+- 从同一个 `SandboxSet` 生成的每个沙箱都拥有独立的 PVC。若要在多个沙箱之间共享同一个 PVC，需要使用 ReadWriteMany 存储类，本文不做展开。
+- 当沙箱通过 `SandboxClaim` 生命周期被删除（例如删除 `SandboxClaim`）时，关联的 PVC 默认会随沙箱一起删除。如果需要保留数据，请通过 StorageClass 配置 PVC 的 `reclaimPolicy`，或在清理前备份数据。

--- a/kruiseagents/user-manuals/ondemand-volume-mount.md
+++ b/kruiseagents/user-manuals/ondemand-volume-mount.md
@@ -1,0 +1,162 @@
+# On-Demand Volume Mounting
+
+This guide shows how to dynamically mount existing Persistent Volumes (PVs) into a sandbox at claim time. This is useful when you want to share storage across multiple sandboxes or attach pre-existing data volumes without defining them in the `SandboxSet` template.
+
+## Overview
+
+On-demand volume mounting lets you declare one or more PV mounts when claiming a sandbox, rather than provisioning a new PVC per sandbox through `volumeClaimTemplates`. The mount is performed by `agent-runtime` and the CSI sidecars injected into the sandbox Pod.
+
+Key characteristics:
+
+- The PV must already exist in the cluster before claiming.
+- The same PV can be mounted into multiple sandboxes (for example, shared datasets or model caches).
+- Mounts can be requested through both the E2B SDK and the `SandboxClaim` CRD.
+
+## Prerequisites
+
+1. The `SandboxSet` used to provide sandboxes must enable the `csi` and `agent-runtime` runtimes. For details on runtime injection, see [Runtime Injection](./runtime-injection.md).
+2. One or more PVs must already exist in the cluster and be accessible from the sandbox nodes.
+3. If your CSI driver requires credentials, the corresponding Secret must be created in advance and referenced by the PV.
+
+## Enable Mount Capability in SandboxSet
+
+Add the `csi` and `agent-runtime` entries to `spec.runtimes` of your `SandboxSet`. The framework will automatically inject the required CSI sidecars and `agent-runtime` into every sandbox created from this template.
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: shared-storage-template
+  namespace: default
+spec:
+  replicas: 3
+  runtimes:
+    - name: csi            # Enable dynamic volume mounting
+    - name: agent-runtime  # Required for mount orchestration
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: ubuntu:latest
+          command: ["sleep", "infinity"]
+```
+
+## Prepare a PersistentVolume
+
+Create a PV object backed by your storage system. The example below uses a generic CSI driver; replace the `driver`, `volumeHandle`, and `volumeAttributes` with values appropriate for your CSI provider.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: shared-pv
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 50Gi
+  csi:
+    driver: csi-driver.example.com
+    volumeHandle: shared-pv
+    volumeAttributes:
+      server: <STORAGE_SERVER_ADDRESS>
+      share: <STORAGE_SHARE_NAME>
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  volumeMode: Filesystem
+```
+
+> Replace the CSI driver name and `volumeAttributes` with the actual values required by your storage backend. If your CSI driver requires credentials, configure them according to the driver's documentation.
+
+## Mount Volumes When Claiming
+
+Choose either the E2B SDK or `SandboxClaim` to request the mount at claim time.
+
+### Via E2B SDK
+
+Use the `e2b.agents.kruise.io/csi-volume-config` extension with a JSON array to declare one or more volume mounts.
+
+```python
+import json
+from e2b_code_interpreter import Sandbox
+
+csi_config = json.dumps([
+    {"pvName": "shared-pv-1", "mountPath": "/data1"},
+    {"pvName": "shared-pv-2", "mountPath": "/data2", "subPath": "sub/dir", "readOnly": True}
+])
+
+sbx = Sandbox.create(template="shared-storage-template", timeout=300, metadata={
+    "e2b.agents.kruise.io/csi-volume-config": csi_config
+})
+```
+
+| Field       | Type    | Description                                   | Required |
+|-------------|---------|-----------------------------------------------|----------|
+| `pvName`    | String  | Name of the existing PV                       | Yes      |
+| `mountPath` | String  | Mount target path in the container            | Yes      |
+| `subPath`   | String  | Sub path within the persistent volume         | No       |
+| `readOnly`  | Boolean | Whether to mount the volume as read-only      | No       |
+
+> The mount target path must be an empty directory; otherwise the mount will fail.
+
+### Via SandboxClaim
+
+Declare the `dynamicVolumesMount` field in your `SandboxClaim`:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: shared-storage-claim
+  namespace: default
+spec:
+  templateName: shared-storage-template
+  replicas: 1
+  claimTimeout: 5m
+  dynamicVolumesMount:
+    - pvName: "shared-pv-1"
+      mountPath: "/data1"
+    - pvName: "shared-pv-2"
+      mountPath: "/data2"
+      subPath: "sub/dir"
+      readOnly: true
+```
+
+Field description:
+
+| Field       | Description                                   | Required |
+|-------------|-----------------------------------------------|----------|
+| `pvName`    | Name of the existing PV                       | Yes      |
+| `mountPath` | Mount target path in the container            | Yes      |
+| `subPath`   | Sub path within the persistent volume         | No       |
+| `readOnly`  | Whether to mount the volume as read-only      | No       |
+
+## Verify the Mount
+
+After the `SandboxClaim` reaches the `Completed` phase, list the sandboxes allocated by the claim:
+
+```bash
+kubectl get sandbox -n default -l agents.kruise.io/claim-name=shared-storage-claim
+```
+
+Expected output:
+
+```text
+NAME                          STATUS    AGE
+shared-storage-template-xxx   Running   22h
+```
+
+Run a command inside the sandbox Pod to verify the mount:
+
+```bash
+kubectl exec -it <POD_NAME> -- df -h /data1
+```
+
+You should see the mounted volume at the requested path.
+
+## Notes
+
+- On-demand volume mounting relies on `agent-runtime` and CSI sidecars. It may affect sandbox delivery speed compared to claiming a sandbox without extra mounts.
+- The mount target directory must exist and be empty in the container image; otherwise the CSI mount will fail.
+- If `subPath` is specified, the sub-directory is not automatically created on the storage backend. Ensure it exists before mounting, or use a storage driver that creates missing directories.
+- This feature currently supports sandboxes claimed from a warm pool, created on no stock, and in-place image upgrades. It does not restore mounts when a sandbox is recovered from a checkpoint.

--- a/kruiseagents/user-manuals/sandbox-claim.md
+++ b/kruiseagents/user-manuals/sandbox-claim.md
@@ -342,25 +342,10 @@ and will also affect delivery efficiency to some extent.
 <Tabs>
   <TabItem value="E2B" label="E2B">
 
-> The following extension keys are OpenKruise Agents extension fields and will not be added to the Sandbox resource as
+> The following extension key is an OpenKruise Agents extension field and will not be added to the Sandbox resource as
 > metadata.
 
-**Single volume mount:**
-
-```python
-from e2b_code_interpreter import Sandbox
-
-sbx = Sandbox.create(template="some-template", timeout=300, metadata={
-    "e2b.agents.kruise.io/csi-volume-name": "oss-pv-test",
-    "e2b.agents.kruise.io/csi-mount-point": "/data",
-    # Optional: specify a sub path within the persistent volume
-    "e2b.agents.kruise.io/csi-subpath": "sub/dir"
-})
-```
-
-**Multiple volumes mount:**
-
-To mount multiple volumes at once, use the `e2b.agents.kruise.io/csi-volume-config` extension with a JSON array:
+Use the `e2b.agents.kruise.io/csi-volume-config` extension with a JSON array to declare one or more volume mounts:
 
 ```python
 import json
@@ -378,12 +363,12 @@ sbx = Sandbox.create(template="some-template", timeout=300, metadata={
 
 Parameter description:
 
-| Extension Key                            | Description                                   | Required           |
-|------------------------------------------|-----------------------------------------------|--------------------|
-| `e2b.agents.kruise.io/csi-volume-name`   | Persistent volume name                        | Yes (single mount) |
-| `e2b.agents.kruise.io/csi-mount-point`   | Mount target path in container                | Yes (single mount) |
-| `e2b.agents.kruise.io/csi-subpath`       | Sub path within the persistent volume         | No                 |
-| `e2b.agents.kruise.io/csi-volume-config` | JSON array of mount configs (for multi-mount) | Yes (multi mount)  |
+| Field       | Description                                   | Required |
+|-------------|-----------------------------------------------|----------|
+| `pvName`    | Persistent volume name                        | Yes      |
+| `mountPath` | Mount target path in container                | Yes      |
+| `subPath`   | Sub path within the persistent volume         | No       |
+| `readOnly`  | Whether to mount as read-only                 | No       |
 
   </TabItem>
   <TabItem value="SandboxClaim" label="SandboxClaim">

--- a/kruiseagents/user-manuals/volume-claim-template.md
+++ b/kruiseagents/user-manuals/volume-claim-template.md
@@ -1,0 +1,187 @@
+# Volume Claim Templates
+
+This guide shows how to use `volumeClaimTemplates` in `SandboxSet` to provide persistent storage for OpenKruise Agents sandboxes.
+
+## The Purpose of Sandbox Volumes
+
+By default, containers are ephemeral, meaning any data generated or modified inside a sandbox is lost when the underlying Pod terminates.
+
+The introduction of `volumeClaimTemplates` into the `SandboxSet` API solves this by allowing each sandbox instance to dynamically provision its own Persistent Volume Claim (PVC). Using semantics identical to a Kubernetes StatefulSet, this functionality allows you to define a storage template once and have OpenKruise Agents automatically create, attach, and manage independent storage volumes for every sandbox spawned from that template.
+
+Common use cases include:
+
+- **Caching dependencies**: Storing downloaded packages (such as `node_modules` or pip caches) across agent runs to speed up executions.
+- **Preserving state**: Maintaining logs, build artifacts, or internal agent databases uniquely tied to specific sandbox sessions.
+- **Warm pools with state**: Pre-warming sandboxes (`SandboxSet`) with attached storage so they are immediately ready to perform heavy I/O operations without waiting for initial storage provisioning.
+
+## How It Works Under the Hood
+
+1. You define a `volumeClaimTemplates` list inside your `SandboxSet`.
+2. When the `SandboxSet` controller provisions a new sandbox, the volume claim templates are seamlessly propagated to the individual `Sandbox` custom resources.
+3. The controller then provisions the associated PVCs and merges them into the underlying Pod specifications, mounting them inside the container.
+4. When a sandbox Pod is recreated (for example, due to node eviction or rolling update), the same PVC is reattached to the new Pod, preserving the data.
+
+## Create a SandboxSet with Volume Claims
+
+To use persistent storage, add the `volumeClaimTemplates` array to your `SandboxSet` specification and reference the claim name in the `volumeMounts` of your container.
+
+The following example assumes a StorageClass named `standard` exists in your cluster. If your cluster does not provide a default StorageClass, create one first or replace `storageClassName` with an available class.
+
+Create a file named `sandboxset-with-volume.yaml`:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: stateful-sandboxset
+  namespace: default
+spec:
+  replicas: 3
+  # 1. Define the dynamic volume configuration here
+  volumeClaimTemplates:
+  - metadata:
+      name: agent-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: standard
+      resources:
+        requests:
+          storage: 1Gi
+  # 2. Reference the exact name of the volume claim in the container
+  template:
+    spec:
+      containers:
+      - name: sandbox-agent
+        image: ubuntu:latest
+        command: ["sleep", "infinity"]
+        volumeMounts:
+        - name: agent-data
+          mountPath: /data
+```
+
+Apply the template to your Kubernetes cluster:
+
+```bash
+kubectl apply -f sandboxset-with-volume.yaml
+```
+
+Wait until the warm pool is ready:
+
+```bash
+kubectl get sbs stateful-sandboxset
+```
+
+Expected output:
+
+```text
+NAME                  REPLICAS   AVAILABLE   UPDATEREVISION   AGE
+stateful-sandboxset   3          3           xxxxxxxx         92s
+```
+
+## Claim a Sandbox via SandboxClaim
+
+Now that the warm pool is ready, you can claim an actual sandbox instance by creating a `SandboxClaim`.
+
+Create a file named `sandbox-claim.yaml`:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: my-stateful-sandbox
+  namespace: default
+spec:
+  templateName: stateful-sandboxset
+```
+
+Apply the claim:
+
+```bash
+kubectl apply -f sandbox-claim.yaml
+```
+
+Wait until the claim is completed:
+
+```bash
+kubectl get sbc my-stateful-sandbox
+```
+
+Expected output:
+
+```text
+NAME                    PHASE       TEMPLATE              DESIRED   CLAIMED   AGE
+my-stateful-sandbox     Completed   stateful-sandboxset   1         1         41s
+```
+
+## Verify the Automatically Provisioned Storage
+
+When you applied the `SandboxClaim`, the `SandboxSet` controller automatically intercepted the `volumeClaimTemplates` definition, created a dedicated PVC, and attached it to your sandbox's Pod.
+
+List the PVCs to confirm the volume was created. The PVC name is composed of the claim name and the sandbox Pod name:
+
+```bash
+kubectl get pvc
+```
+
+You should see a newly bound PVC named like `agent-data-<sandbox-pod-name>`.
+
+If you execute into the sandbox container, you can verify that the volume is mounted correctly at the `/data` directory:
+
+```bash
+kubectl exec -it <sandbox-pod-name> -- df -h /data
+```
+
+## Validate Data Persistence
+
+To validate data persistence, destroy the underlying Pod to simulate a crash or eviction, and then verify that the data survived when the controller spins up a replacement.
+
+### 1. Write data to the persistent volume
+
+Execute a command inside your running sandbox container to create a file within the mounted `/data` directory:
+
+```bash
+kubectl exec -it <sandbox-pod-name> -- sh -c "echo 'This data will survive a pod crash!' > /data/evidence.txt"
+```
+
+### 2. Verify the data exists
+
+Read the file back to ensure it was written successfully:
+
+```bash
+kubectl exec -it <sandbox-pod-name> -- cat /data/evidence.txt
+```
+
+### 3. Simulate a failure by deleting the Pod
+
+Because sandboxes are managed by the `SandboxSet` controller, deleting the Pod directly simulates an unexpected failure.
+
+```bash
+kubectl delete pod <sandbox-pod-name>
+```
+
+### 4. Wait for the controller to recreate the sandbox
+
+The `SandboxSet` controller will detect that the Pod is missing and automatically recreate it. Because `volumeClaimTemplates` use StatefulSet-like semantics, the controller will reattach the exact same PVC to the new Pod.
+
+Watch the Pods until the new one is running:
+
+```bash
+kubectl get pods -w
+```
+
+### 5. Verify the data survived
+
+Once the new replacement Pod is in the `Running` state, execute into it and read the file again:
+
+```bash
+kubectl exec -it <new-sandbox-pod-name> -- cat /data/evidence.txt
+```
+
+You should see the text `This data will survive a pod crash!` printed in your terminal.
+
+## Notes
+
+- The `volumeClaimTemplates` field is a sibling of `template` in the `SandboxSet` spec, not nested inside `template.spec`.
+- Each sandbox spawned from the `SandboxSet` receives its own independent PVC. Sharing the same PVC across multiple sandboxes requires a ReadWriteMany storage class and is not covered by this guide.
+- When a sandbox is deleted through the `SandboxClaim` lifecycle (for example, by deleting the `SandboxClaim`), the associated PVC is deleted together with the sandbox by default. If you need to retain the data, configure the PVC `reclaimPolicy` through your StorageClass or back up the data before cleanup.

--- a/sidebars-kruiseagents.js
+++ b/sidebars-kruiseagents.js
@@ -34,6 +34,15 @@ module.exports = {
                 'user-manuals/checkpoint',
                 'user-manuals/sandbox-update',
                 'user-manuals/api-keys-and-teams',
+                {
+                    type: 'category',
+                    label: 'Storage Management',
+                    collapsed: false,
+                    items: [
+                        'user-manuals/volume-claim-template',
+                        'user-manuals/ondemand-volume-mount',
+                    ],
+                },
             ],
         },
         {


### PR DESCRIPTION
Add user manuals for Kruise Agents storage management:

- Volume Claim Templates: dynamically provision PVCs per Sandbox via SandboxSet.
- On-Demand Volume Mounting: mount existing PVs into sandboxes at claim time using E2B SDK or SandboxClaim.

Also remove the legacy single-volume E2B mount API from both the new doc and the existing sandbox-claim doc; the csi-volume-config JSON-array API is now used consistently.