### PR TITLE
docs(rollouts): add MinReadySeconds strategy section to multi-batch release manual

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-rollouts/current/user-manuals/strategy-multi-batch-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-rollouts/current/user-manuals/strategy-multi-batch-update.md
@@ -81,3 +81,90 @@ spec:
 - 在第 3 批中，将更新 `100%` 的 Pod，而 `0` 个 Pod 仍然保持在稳定版本。
 
 与[金丝雀发布策略](strategy-canary-update.md)不同，**在发布过程中不会创建额外的 Deployment**。
+
+## MinReadySeconds 策略（Alpha）
+
+原生 Deployment 可以使用基于 Deployment 自身 `minReadySeconds` 字段的另一种多批次发布策略。这是一个 **alpha** 功能，由 `MinReadySecondsStrategy` 特性开关选择，**默认关闭**。
+
+### 设计思路
+
+Kubernetes 只有在 Pod 保持 `Ready` 达到 `minReadySeconds` 之后，才会把它视为 `Available`。默认的多批次路径会暂停原生 Deployment，并把 `spec.strategy.type` 改写成 `Recreate`，由 Rollout 控制器自己推进分区。这条路径是可用的，但改写的是一个破坏性字段：如果在恢复原策略之前 Rollout 控制器或 webhook 不可用，之后对 pod template 的更新就可能被原生 Deployment 控制器按 Recreate 语义处理。
+
+MinReadySeconds 策略从头到尾都不改 `strategy.type`。它把 `minReadySeconds` 膨胀到极大值，让新更新的 Pod 可以 `Ready` 但暂时不是 `Available`，再按批次扩大 `maxUnavailable`。原生 `RollingUpdate` 控制器继续负责替换 Pod，Rollout 只控制节奏。最坏情况下 Pod 会停留在 Ready-but-not-Available，而不会被一次性 Recreate。
+
+### 如何开启
+
+安装或升级 kruise-rollout 时，通过 Helm 的 `rollout.featureGates` 参数开启特性开关：
+
+```bash
+$ helm install kruise-rollout openkruise/kruise-rollout \
+  --set rollout.featureGates="AdvancedDeployment=true,MinReadySecondsStrategy=true"
+```
+
+或者，在已有安装上直接修改 controller manager 的启动参数：
+
+```bash
+$ kubectl patch deployment kruise-rollout-controller-manager -n kruise-rollout --type='json' \
+  -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/1", "value": "--feature-gates=AdvancedDeployment=true,MinReadySecondsStrategy=true"}]'
+```
+
+开启后，集群中所有 partition 风格的 Deployment 发布都将使用 MinReadySeconds 策略。Rollout CR 的形态不变：
+
+```yaml
+apiVersion: rollouts.kruise.io/v1beta1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+spec:
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: workload-demo
+  strategy:
+    canary:
+      enableExtraWorkloadForCanary: false
+      steps:
+      - replicas: 1
+      - replicas: 50%
+      - replicas: 100%
+```
+
+### 与默认策略的区别
+
+HPA / 外部扩缩容和 PodDisruptionBudget 在**两种策略下都生效**。Paused 的 Deployment 仍然会处理副本数变化，因此 Recreate 路径并不会把 HPA 冻住；PDB 同样继续约束驱逐。真正的差异在于：各自改了 Deployment 的哪些字段，以及由谁驱动更新。
+
+| Deployment 上改了什么 | 默认（基于 Recreate） | MinReadySeconds |
+|---|---|---|
+| `spec.paused` | 设为 `true`（暂停原生更新控制器） | 保持 `false`（原生控制器继续运行） |
+| `spec.strategy.type` | 改写为 `Recreate` | 保持 `RollingUpdate` |
+| `spec.minReadySeconds` | 不改 | 发布期间膨胀 |
+| `spec.progressDeadlineSeconds` | 不改 | 发布期间膨胀 |
+| `spec.strategy.rollingUpdate.maxUnavailable` | 随 `RollingUpdate` 清空，分区由 Rollout 驱动 | 先膨胀，再按批次推进 |
+| `spec.strategy.rollingUpdate.maxSurge` | 由 Rollout 控制器驱动 | 交给原生 Deployment 控制器（尊重用户配置） |
+| 注解 | 发布进行中标记 | 额外写入三条 `rollouts.kruise.io/original-*` 快照（见下） |
+| 批次就绪条件 | 等待更新后的 Pod 变为 `Ready` | 等待更新后的 Pod 在**原始** `minReadySeconds` 下变为 `Available` |
+| 发布中控制器故障 | 批次停止推进，直到 Rollout 恢复；若此时有人改 pod template，残留的 `Recreate` 是风险 | 原生 Deployment 控制器仍按当前 `maxUnavailable` 预算继续更新 |
+
+MinReadySeconds 发布开始时，控制器会把用户原来的 `minReadySeconds`、`progressDeadlineSeconds` 和 `maxUnavailable` 保存到：
+
+- `rollouts.kruise.io/original-min-ready-seconds`
+- `rollouts.kruise.io/original-progress-deadline-seconds`
+- `rollouts.kruise.io/original-max-unavailable`
+
+然后膨胀这三个 spec 字段以接管发布节奏，并逐步提高 `maxUnavailable` 驱动每一批。发布结束后恢复原始字段并删除这些注解。
+
+因为 `progressDeadlineSeconds` 被膨胀了，MinReadySeconds 接管期间原生 Deployment 控制器**不会**打上 `ProgressDeadlineExceeded`。批次等待较久时，不要把它当成一次失败的原生 Deployment 发布。请看 Rollout / BatchRelease 的状态，以及 MinReady 的 stuck / degraded 信号。
+
+### 操作注意
+
+**不要手工修改** `rollouts.kruise.io/original-*` 注解。它们是恢复原始字段的契约：一旦被删除或改坏，发布会进入 degraded，并**卡住等待人工介入**（把注解恢复正确，或取消 / finalize 这次发布以便回收原始字段）。
+
+发布过程中，也不要指望手工改 `minReadySeconds`、`progressDeadlineSeconds` 或 `maxUnavailable` 会生效。这些 spec 字段由 MinReadySeconds 控制器持有：admission 会把可用性字段重新膨胀回去，`maxUnavailable` 也会被收敛回当前批次预算。需要换节奏时改 Rollout 的 steps；需要改 Deployment 自己的可用性配置时，等这次发布结束再改。
+
+### 行为说明
+
+- **批次进度**：每批把 `maxUnavailable` 提高到批次目标；控制器会等待更新的 Pod 在原始 `minReadySeconds` 下变为可用后再扩大预算。当金丝雀批次较小、后续批次很大时，预算会按用户原始 `maxUnavailable` 滑动窗口逐步放开，而不是一次性跳变。
+- **回滚 / 连续发布**：与默认策略一致；重新膨胀时刷新原始可用性字段。
+- **升级兼容性**：如果升级控制器开启特性开关时，某个 Deployment 正处于之前基于 Recreate 策略的发布中，该进行中的发布会继续使用 Recreate 策略直到完成，而不会中途切换。
+- **发布中关闭开关**：仍带 `rollouts.kruise.io/original-*` 注解的 Deployment 会继续由 MinReadySeconds 控制器接管直到 finalize，从而干净地恢复原始字段，而不会被卡在中间状态。
+- **限制（alpha）**：该策略仅适用于原生 Deployment；其他工作负载类型（CloneSet、StatefulSet、DaemonSet）继续使用默认的 partition 策略。用户 Deployment 上的 `strategy.type=Recreate` 会被拒绝并上报为 degraded。

--- a/rollouts/user-manuals/strategy-multi-batch-update.md
+++ b/rollouts/user-manuals/strategy-multi-batch-update.md
@@ -90,3 +90,91 @@ When applying a new revision to `workload-demo`, the rollout progresses through 
 - `100%` Pods will be updated and `0` Pods is still at stable revision in the 3-rd batch.
 
 Different from [canary release strategy](strategy-canary-update.md), **No extra Deployment is created during rollout progressing**.
+
+## MinReadySeconds Strategy (Alpha)
+
+Native Deployments can use an alternative multi-batch strategy based on the Deployment's own `minReadySeconds` field. It is an **alpha** feature selected by the `MinReadySecondsStrategy` feature gate, which is **disabled by default**.
+
+### Why This Strategy Exists
+
+Kubernetes treats a Pod as `Available` only after it has stayed `Ready` for `minReadySeconds`. The default multi-batch path for native Deployments pauses the workload and rewrites `spec.strategy.type` to `Recreate`, so the Rollout controller can drive partitions itself. That works, but it mutates a destructive field: if the Rollout controller or webhook is unavailable before the original strategy is restored, a later pod-template update can be handled by the native Deployment controller with Recreate semantics.
+
+The MinReadySeconds strategy never changes `strategy.type`. Instead it inflates `minReadySeconds` so newly updated Pods become `Ready` but stay not `Available`, then widens `maxUnavailable` batch by batch. The native `RollingUpdate` controller keeps replacing Pods; Rollout only gates the pace. In the worst case Pods remain `Ready-but-not-Available` — they are never recreated en masse.
+
+### How to Enable
+
+Enable the feature gate via the Helm `rollout.featureGates` parameter when installing or upgrading kruise-rollout:
+
+```bash
+$ helm install kruise-rollout openkruise/kruise-rollout \
+  --set rollout.featureGates="AdvancedDeployment=true,MinReadySecondsStrategy=true"
+```
+
+Or, on an existing installation, patch the controller manager args:
+
+```bash
+$ kubectl patch deployment kruise-rollout-controller-manager -n kruise-rollout --type='json' \
+  -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/1", "value": "--feature-gates=AdvancedDeployment=true,MinReadySecondsStrategy=true"}]'
+```
+
+Once enabled, every partition-style Deployment rollout in the cluster uses the MinReadySeconds strategy. The Rollout CR shape is unchanged:
+
+```yaml
+apiVersion: rollouts.kruise.io/v1beta1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+spec:
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: workload-demo
+  strategy:
+    canary:
+      enableExtraWorkloadForCanary: false
+      steps:
+      - replicas: 1
+      - replicas: 50%
+      - replicas: 100%
+```
+
+### How It Differs from the Default Strategy
+
+HPA / external scaling and PodDisruptionBudgets work with **both** strategies. A paused Deployment still processes replica changes, so Recreate-based rollouts are not frozen for HPA; PDBs continue to apply as well. The real difference is how each strategy mutates the Deployment and who drives the update.
+
+| What changes on the Deployment | Default (Recreate-based) | MinReadySeconds |
+|---|---|---|
+| `spec.paused` | Set to `true` (native update controller paused) | Left `false` (native controller keeps running) |
+| `spec.strategy.type` | Rewritten to `Recreate` | Left as `RollingUpdate` |
+| `spec.minReadySeconds` | Unchanged | Inflated for the duration of the rollout |
+| `spec.progressDeadlineSeconds` | Unchanged | Inflated for the duration of the rollout |
+| `spec.strategy.rollingUpdate.maxUnavailable` | Cleared with `RollingUpdate`; partition is driven by Rollout | Inflated, then advanced batch by batch |
+| `spec.strategy.rollingUpdate.maxSurge` | Driven by the Rollout controller | Left to the native Deployment controller (the user-configured value is respected) |
+| Annotations | Rollout progressing markers | Plus three `rollouts.kruise.io/original-*` snapshots (see below) |
+| Batch readiness | Waits until updated Pods are `Ready` | Waits until updated Pods are `Available` under the **original** `minReadySeconds` |
+| Controller outage during rollout | Pods stop advancing until Rollout recovers; leftover `Recreate` is the hazard if someone then edits the pod template | Native Deployment controller keeps updating within the current `maxUnavailable` budget |
+
+During a MinReadySeconds rollout the controller snapshots the user's `minReadySeconds`, `progressDeadlineSeconds`, and `maxUnavailable` into:
+
+- `rollouts.kruise.io/original-min-ready-seconds`
+- `rollouts.kruise.io/original-progress-deadline-seconds`
+- `rollouts.kruise.io/original-max-unavailable`
+
+It then inflates those three spec fields so it can own the rollout pace, and progressively raises `maxUnavailable` to drive each batch. After the rollout finishes, the original fields are restored and the annotations are removed.
+
+Because `progressDeadlineSeconds` is inflated, the native Deployment controller **does not** set the `ProgressDeadlineExceeded` condition while MinReadySeconds is in control. A long-running batch is therefore not reported as a failed native Deployment rollout. Watch the Rollout / BatchRelease status (and the MinReady stuck / degraded signals) instead of that Deployment condition.
+
+### Operation Notice
+
+Do **not** edit the `rollouts.kruise.io/original-*` annotations by hand. They are the restore contract: if they are deleted or corrupted, the rollout is marked degraded and **pauses until you intervene** (restore the annotations, or cancel / finalize the rollout so the original fields can be recovered).
+
+During the rollout, also do **not** expect manual edits to `minReadySeconds`, `progressDeadlineSeconds`, or `maxUnavailable` to stick. Those spec fields are owned by the MinReadySeconds controller: admission re-inflates the availability fields, and `maxUnavailable` is converged back to the current batch budget. Change the Rollout steps if you need a different pace; wait until the rollout finishes if you need to change the Deployment's own availability settings.
+
+### Behavior Notes
+
+- **Batch progress**: each batch increases `maxUnavailable` up to the batch target; the controller waits for the updated pods to become available under the original `minReadySeconds` before widening the budget. With a large batch after a small canary, the budget advances in sliding windows of the user's original `maxUnavailable` instead of one jump.
+- **Rollback / continuous release**: works the same way as the default strategy; original availability fields are refreshed on re-inflation.
+- **Upgrade compatibility**: if the controller is upgraded to enable the gate while a Deployment is mid-rollout under the previously-started Recreate-based strategy, that in-progress release keeps the Recreate strategy until it finishes, instead of being switched mid-flight.
+- **Gate off mid-rollout**: a Deployment still carrying the `rollouts.kruise.io/original-*` annotations keeps using the MinReadySeconds controller until finalized, so it restores the original fields cleanly instead of being stranded.
+- **Limitations (alpha)**: the strategy applies to native Deployments only; other workload types (CloneSet, StatefulSet, DaemonSet) keep the default partition strategy. `strategy.type=Recreate` on the user Deployment is rejected and reported as degraded.
+


### PR DESCRIPTION
Add user documentation for the alpha `MinReadySecondsStrategy` feature gate of the Deployment multi-batch release strategy, in both English and Chinese:

- How to enable the feature gate (Helm `rollout.featureGates` or controller manager args).
- How it differs from the default Recreate-based strategy: the native Deployment controller keeps running, availability is checked against the original `minReadySeconds`, and HPA / PDB keep working.
- Behavior notes (batch progress, rollback, upgrade compatibility, gate-off mid-rollout) and alpha limitations.

Files changed:

- `rollouts/user-manuals/strategy-multi-batch-update.md`
- `i18n/zh/docusaurus-plugin-content-docs-rollouts/current/user-manuals/strategy-multi-batch-update.md`