### PR TITLE
docs(kruiseagents): document warm pool scaling via scale subresource and patch-based SandboxSet updates

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/sandbox-update.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/sandbox-update.md
@@ -23,84 +23,9 @@ OpenKruise Agents 支持两种升级场景：
 
 ## 升级预热池沙箱（SandboxSet）
 
-### 工作原理
+预热池中的空闲沙箱通过修改 SandboxSet 模板进行升级，模板变更会触发池内沙箱的滚动升级。需要注意的是，控制器会持续将预热池的状态写回 SandboxSet 对象，因此修改副本数必须通过 `scale` 子资源进行，模板变更也必须以 patch 的方式提交，而不是整体更新。
 
-当你修改 SandboxSet 的 `spec.template` 字段时，控制器会检测到模板变更并对池中的沙箱执行 **滚动升级**。控制器会：
-
-1. 根据更新后的模板计算出新的 `updateRevision` 哈希。
-2. 按批次删除旧版本的沙箱（遵循 `maxUnavailable` 限制）。
-3. 使用更新后的模板创建新的沙箱，以维持期望的副本数。
-
-在 **扩容** 时，新创建的沙箱会使用最新的模板。在 **缩容** 时，会优先移除旧版本的沙箱。
-
-### 配置
-
-```yaml
-apiVersion: agents.kruise.io/v1alpha1
-kind: SandboxSet
-metadata:
-  name: my-sandbox-pool
-  namespace: default
-spec:
-  replicas: 10
-  updateStrategy:
-    # 在升级过程中允许不可用的沙箱最大数量或百分比。
-    # 可以是绝对值（如 5）或百分比（如 "10%"）。
-    # 默认值："20%"
-    maxUnavailable: "20%"
-  template:
-    spec:
-      containers:
-        - name: sandbox
-          image: my-registry/sandbox-image:v2   # 在此处更新镜像版本
-          resources:
-            requests:
-              cpu: "1"
-              memory: "512Mi"
-            limits:
-              cpu: "2"
-              memory: "1Gi"
-```
-
-要触发升级，只需更新 `spec.template` 下的任意字段（如容器镜像、资源、环境变量），然后应用变更：
-
-```bash
-kubectl apply -f sandboxset.yaml
-```
-
-### 监控进度
-
-通过查看 SandboxSet 状态来监控滚动升级：
-
-```bash
-kubectl get sandboxset my-sandbox-pool -o wide
-```
-
-输出示例：
-
-```
-NAME              REPLICAS   AVAILABLE   UPDATEDREPLICAS   UPDATEDAVAILABLEREPLICAS   UPDATEREVISION   AGE
-my-sandbox-pool   10         8           6                 5                          a1b2c3d4         30m
-```
-
-| 字段 | 说明 |
-|---|---|
-| `REPLICAS` | 沙箱总数（创建中 + 可用 + 运行中 + 已暂停） |
-| `AVAILABLE` | 可被认领的沙箱数量 |
-| `UPDATEDREPLICAS` | 已更新到最新版本的沙箱数量 |
-| `UPDATEDAVAILABLEREPLICAS` | 已更新且可用的沙箱数量 |
-| `UPDATEREVISION` | 当前期望模板版本的哈希值 |
-
-当 `UPDATEDAVAILABLEREPLICAS` 等于期望的 `REPLICAS` 数量时，滚动升级即告完成。
-
-你也可以查看单个沙箱的版本：
-
-```bash
-kubectl get sandboxes -l agents.kruise.io/sandbox-template=my-sandbox-pool -o custom-columns=\
-NAME:.metadata.name,\
-PHASE:.status.phase,\
-REVISION:.status.updateRevision
-```
+完整的操作说明（包括如何使用 `scale` 子资源和以 patch 方式更新），请参考 [预热池管理](./warmpool-management.md) 中的 [升级预热池沙箱](./warmpool-management.md#升级预热池沙箱)。
 
 ## 升级已认领沙箱（SandboxUpdateOps）
 

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
@@ -1,6 +1,6 @@
 # 预热池管理
 
-本文将介绍如何通过 `SandboxSet` 创建预热池。
+本文将介绍如何通过 `SandboxSet` 创建、扩缩容和升级预热池。
 
 ## 预热池的作用
 
@@ -58,9 +58,25 @@ NAME   REPLICAS   AVAILABLE   UPDATEREVISION   AGE
 demo   10         10          78dd8599cf       19m
 ```
 
-## 扩容与更新策略
+## 预热池扩缩容
 
-`SandboxSet` 提供两个策略字段，用于控制扩容和滚动更新的节奏，从而尽量减少对集群资源和服务可用性的影响。
+预热池的大小由 SandboxSet 的 `spec.replicas` 控制。由于控制器会持续将预热池的状态（沙箱的创建、删除、可用数量、版本等）写回 SandboxSet 对象，繁忙的 SandboxSet 会被频繁更新，**因此修改副本数必须通过 SandboxSet 的 `scale` 子资源进行，而不是更新整个对象**。整体更新会携带此前读取到的 `resourceVersion`，与控制器的写入相互冲突，在繁忙的 SandboxSet 上会频繁出现写冲突；而 `scale` 子资源只修改 `spec.replicas`，可以避免这些冲突。
+
+例如，使用直接操作 `scale` 子资源的 `kubectl scale` 命令对预热池进行扩缩容：
+
+```bash
+# 将预热池扩容到 20 个沙箱
+kubectl scale sbs demo --replicas=20 -n default
+
+# 将预热池缩容到 5 个沙箱
+kubectl scale sbs demo --replicas=5 -n default
+```
+
+:::caution
+不要在客户端中发起整体 `Update` 来扩缩容——对于繁忙的 SandboxSet，这会导致频繁的 `409 Conflict` 错误；也不要通过 `kubectl edit` 将 `replicas` 与其他模板字段一起修改。扩缩容请始终通过 `scale` 子资源进行。如果你通过 Kubernetes 客户端（Go client、REST API 等）操作 SandboxSet，同样应当使用 `scale` 子资源，例如 controller-runtime 中的 `client.SubResource("scale").Update(...)`，而不是发起整体 `Update`。
+:::
+
+`SandboxSet` 还提供策略字段，用于控制扩容和滚动更新的节奏，从而尽量减少对集群资源和服务可用性的影响。
 
 ### `scaleStrategy.maxUnavailable`
 
@@ -81,6 +97,51 @@ spec:
 扩容时，新创建的沙箱会按照该限制分批启动。例如，若 `maxUnavailable: 5`，从 0 扩容到 20，沙箱会以每批 5 个的方式创建——每一批只有在上一批变为 `available` 后才会开始创建。
 :::
 
+## 升级预热池沙箱
+
+当你修改 SandboxSet 的 `spec.template` 字段时，控制器会检测到模板变更并对池中的沙箱执行 **滚动升级**。
+
+### 工作原理
+
+控制器会：
+
+1. 根据更新后的模板计算出新的 `updateRevision` 哈希。
+2. 按批次删除旧版本的沙箱（遵循 `maxUnavailable` 限制）。
+3. 使用更新后的模板创建新的沙箱，以维持期望的副本数。
+
+在 **扩容** 时，新创建的沙箱会使用最新的模板。在 **缩容** 时，会优先移除旧版本的沙箱。
+
+### 配置
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: my-sandbox-pool
+  namespace: default
+spec:
+  replicas: 10
+  updateStrategy:
+    # 在升级过程中允许不可用的沙箱最大数量或百分比。
+    # 可以是绝对值（如 5）或百分比（如 "10%"）。
+    # 默认值："20%"
+    maxUnavailable: "20%"
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: my-registry/sandbox-image:v2   # 在此处更新镜像版本
+          resources:
+            requests:
+              cpu: "1"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "1Gi"
+```
+
+要触发升级，只需修改 `spec.template` 下的任意字段（如容器镜像、资源、环境变量），并以 patch 的方式提交变更，见 [使用 Patch 而不是整体更新](#使用-patch-而不是整体更新)。
+
 ### `updateStrategy.maxUnavailable`
 
 该字段控制在 **滚动更新** 期间（通过修改 `spec.template` 触发）允许处于 **不可用** 状态的沙箱最大数量或百分比。它决定了滚动更新的批次大小。
@@ -96,7 +157,62 @@ spec:
     maxUnavailable: 3
 ```
 
-关于滚动更新工作原理的详细说明，包括监控进度和故障排查，请参考 [升级预热池沙箱（SandboxSet）](./sandbox-update.md#升级预热池沙箱sandboxset)。
+### 使用 Patch 而不是整体更新
+
+对 SandboxSet 的修改（例如更新 `spec.template`）**必须以 patch 的方式提交，而不是整体更新**。控制器会持续将预热池的状态（沙箱的创建、删除、可用数量、版本等）写回 SandboxSet 对象；整体 `Update` 会把整个对象连同此前读取到的 `resourceVersion` 一起提交，因此会频繁出现写冲突（`409 Conflict`），迫使客户端反复重试。而 patch 只携带发生变更的字段，不会与控制器的写入冲突。
+
+例如，使用 `kubectl patch` 更新沙箱镜像：
+
+```bash
+kubectl patch sbs my-sandbox-pool --type merge -p \
+  '{"spec":{"template":{"spec":{"containers":[{"name":"sandbox","image":"my-registry/sandbox-image:v2"}]}}}}'
+```
+
+`kubectl edit` 同理：它会计算原始对象与你编辑结果的差异，并以 patch 的方式提交，因此对繁忙的 SandboxSet 同样安全：
+
+```bash
+kubectl edit sbs my-sandbox-pool -n default
+```
+
+在编辑器中修改 `spec.template` 下的字段（如容器镜像）并保存，kubectl 会以 patch 的方式提交变更。
+
+:::caution
+不要通过整体 `Update`/`Replace` 操作来升级 SandboxSet（例如 `kubectl replace`，或代码中的整体 `Update` 调用）。对于繁忙的 SandboxSet，这会造成频繁的写冲突。
+:::
+
+### 监控进度
+
+通过查看 SandboxSet 状态来监控滚动升级：
+
+```bash
+kubectl get sandboxset my-sandbox-pool -o wide
+```
+
+输出示例：
+
+```
+NAME              REPLICAS   AVAILABLE   UPDATEDREPLICAS   UPDATEDAVAILABLEREPLICAS   UPDATEREVISION   AGE
+my-sandbox-pool   10         8           6                 5                          a1b2c3d4         30m
+```
+
+| 字段 | 说明 |
+|---|---|
+| `REPLICAS` | 沙箱总数（创建中 + 可用 + 运行中 + 已暂停） |
+| `AVAILABLE` | 可被认领的沙箱数量 |
+| `UPDATEDREPLICAS` | 已更新到最新版本的沙箱数量 |
+| `UPDATEDAVAILABLEREPLICAS` | 已更新且可用的沙箱数量 |
+| `UPDATEREVISION` | 当前期望模板版本的哈希值 |
+
+当 `UPDATEDAVAILABLEREPLICAS` 等于期望的 `REPLICAS` 数量时，滚动升级即告完成。
+
+你也可以查看单个沙箱的版本：
+
+```bash
+kubectl get sandboxes -l agents.kruise.io/sandbox-template=my-sandbox-pool -o custom-columns=\
+NAME:.metadata.name,\
+PHASE:.status.phase,\
+REVISION:.status.updateRevision
+```
 
 ## 预热沙箱的获取与补充
 

--- a/kruiseagents/user-manuals/sandbox-update.md
+++ b/kruiseagents/user-manuals/sandbox-update.md
@@ -23,84 +23,9 @@ OpenKruise Agents supports two upgrade scenarios:
 
 ## Upgrade Pre-warmed Pool Sandboxes (SandboxSet)
 
-### How It Works
+Idle sandboxes in a warm pool are upgraded by modifying the SandboxSet template, which triggers a rolling update of the pool. Note that the controller continuously writes the warm pool's state back to the SandboxSet object, so replica count changes must go through the `scale` subresource, and template changes must be submitted as patches instead of full-object updates.
 
-When you modify the `spec.template` field of a SandboxSet, the controller detects the template change and performs a **rolling update** of the sandboxes in the pool. The controller:
-
-1. Computes a new `updateRevision` hash from the updated template.
-2. Deletes old-revision sandboxes in batches (respecting `maxUnavailable`).
-3. Creates new sandboxes with the updated template to maintain the desired replica count.
-
-During **scale-up**, newly created sandboxes use the latest template. During **scale-down**, sandboxes with the old revision are removed first.
-
-### Configuration
-
-```yaml
-apiVersion: agents.kruise.io/v1alpha1
-kind: SandboxSet
-metadata:
-  name: my-sandbox-pool
-  namespace: default
-spec:
-  replicas: 10
-  updateStrategy:
-    # Maximum number or percentage of sandboxes that can be unavailable during the update.
-    # Can be an absolute number (e.g., 5) or a percentage (e.g., "10%").
-    # Default: "20%"
-    maxUnavailable: "20%"
-  template:
-    spec:
-      containers:
-        - name: sandbox
-          image: my-registry/sandbox-image:v2   # Update the image version here
-          resources:
-            requests:
-              cpu: "1"
-              memory: "512Mi"
-            limits:
-              cpu: "2"
-              memory: "1Gi"
-```
-
-To trigger an upgrade, simply update any field under `spec.template` (e.g., container image, resources, environment variables) and apply the change:
-
-```bash
-kubectl apply -f sandboxset.yaml
-```
-
-### Monitoring Progress
-
-Check the SandboxSet status to monitor the rolling update:
-
-```bash
-kubectl get sandboxset my-sandbox-pool -o wide
-```
-
-Example output:
-
-```
-NAME              REPLICAS   AVAILABLE   UPDATEDREPLICAS   UPDATEDAVAILABLEREPLICAS   UPDATEREVISION   AGE
-my-sandbox-pool   10         8           6                 5                          a1b2c3d4         30m
-```
-
-| Field | Description |
-|---|---|
-| `REPLICAS` | Total number of sandboxes (creating + available + running + paused) |
-| `AVAILABLE` | Number of sandboxes ready to be claimed |
-| `UPDATEDREPLICAS` | Number of sandboxes that have been updated to the latest revision |
-| `UPDATEDAVAILABLEREPLICAS` | Number of updated sandboxes that are available |
-| `UPDATEREVISION` | Hash of the current desired template version |
-
-The rolling update is complete when `UPDATEDAVAILABLEREPLICAS` equals the desired `REPLICAS` count.
-
-You can also inspect individual sandbox revisions:
-
-```bash
-kubectl get sandboxes -l agents.kruise.io/sandbox-template=my-sandbox-pool -o custom-columns=\
-NAME:.metadata.name,\
-PHASE:.status.phase,\
-REVISION:.status.updateRevision
-```
+For the complete instructions, including how to use the `scale` subresource and patch-based updates, refer to [Upgrading Pre-warmed Pool Sandboxes](./warmpool-management.md#upgrading-pre-warmed-pool-sandboxes) in [Warm Pool Management](./warmpool-management.md).
 
 ## Upgrade Claimed Sandboxes (SandboxUpdateOps)
 

--- a/kruiseagents/user-manuals/warmpool-management.md
+++ b/kruiseagents/user-manuals/warmpool-management.md
@@ -1,6 +1,6 @@
 # Warm Pool Management
 
-This document introduces how to create a warm pool through `SandboxSet`.
+This document introduces how to create, scale, and upgrade a warm pool through `SandboxSet`.
 
 ## Purpose of Warm Pool
 
@@ -62,9 +62,25 @@ NAME   REPLICAS   AVAILABLE   UPDATEREVISION   AGE
 demo   10         10          78dd8599cf       19m
 ```
 
-## Scaling and Update Strategies
+## Scaling the Warm Pool
 
-`SandboxSet` provides two strategy fields to control the pace of scaling and rolling updates, helping to minimize the impact on cluster resources and service availability.
+The size of a warm pool is controlled by `spec.replicas` of the SandboxSet. Because the controller continuously writes the warm pool's state back to the SandboxSet object (sandbox creation/deletion, available counts, revisions, etc.), a busy SandboxSet is updated very frequently. **Replica count changes must therefore be made through the `scale` subresource of the SandboxSet, instead of updating the whole object**. A full-object update carries the `resourceVersion` read earlier and conflicts with the controller's writes, causing frequent write conflicts on a busy SandboxSet; the `scale` subresource only touches `spec.replicas` and avoids these conflicts.
+
+For example, use `kubectl scale`, which operates on the `scale` subresource directly, to scale the pool:
+
+```bash
+# Scale the warm pool up to 20 sandboxes
+kubectl scale sbs demo --replicas=20 -n default
+
+# Scale the warm pool down to 5 sandboxes
+kubectl scale sbs demo --replicas=5 -n default
+```
+
+:::caution
+Do not scale by issuing a full-object `Update` from a client — on a busy SandboxSet this leads to frequent `409 Conflict` errors — and do not change `replicas` together with other template fields via `kubectl edit`. Always go through the `scale` subresource. If you operate on SandboxSet through a Kubernetes client (Go client, REST API, etc.), likewise target the `scale` subresource, e.g., `client.SubResource("scale").Update(...)` in controller-runtime, instead of issuing a full-object `Update`.
+:::
+
+`SandboxSet` also provides strategy fields to control the pace of scaling and rolling updates, helping to minimize the impact on cluster resources and service availability.
 
 ### `scaleStrategy.maxUnavailable`
 
@@ -85,6 +101,51 @@ spec:
 When scaling up, newly created sandboxes are launched in batches respecting this limit. For example, if `maxUnavailable: 5` and you scale from 0 to 20, sandboxes are created in groups of 5 — each new batch starts only after the previous batch becomes `available`.
 :::
 
+## Upgrading Pre-warmed Pool Sandboxes
+
+When you modify the `spec.template` field of a SandboxSet, the controller detects the template change and performs a **rolling update** of the sandboxes in the pool.
+
+### How It Works
+
+The controller:
+
+1. Computes a new `updateRevision` hash from the updated template.
+2. Deletes old-revision sandboxes in batches (respecting `maxUnavailable`).
+3. Creates new sandboxes with the updated template to maintain the desired replica count.
+
+During **scale-up**, newly created sandboxes use the latest template. During **scale-down**, sandboxes with the old revision are removed first.
+
+### Configuration
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: my-sandbox-pool
+  namespace: default
+spec:
+  replicas: 10
+  updateStrategy:
+    # Maximum number or percentage of sandboxes that can be unavailable during the update.
+    # Can be an absolute number (e.g., 5) or a percentage (e.g., "10%").
+    # Default: "20%"
+    maxUnavailable: "20%"
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: my-registry/sandbox-image:v2   # Update the image version here
+          resources:
+            requests:
+              cpu: "1"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "1Gi"
+```
+
+To trigger an upgrade, modify any field under `spec.template` (e.g., container image, resources, environment variables) and submit the change as a patch (see [Use Patch, Not Full-Object Update](#use-patch-not-full-object-update)).
+
 ### `updateStrategy.maxUnavailable`
 
 This field controls the maximum number or percentage of sandboxes that can be **unavailable** during a **rolling update** (triggered by modifying `spec.template`). It determines the batch size of the rolling update.
@@ -100,7 +161,62 @@ spec:
     maxUnavailable: 3
 ```
 
-For a detailed explanation of how rolling updates work, including monitoring progress and troubleshooting, refer to [Upgrade Pre-warmed Pool Sandboxes (SandboxSet)](./sandbox-update.md#upgrade-pre-warmed-pool-sandboxes-sandboxset).
+### Use Patch, Not Full-Object Update
+
+Modifications to a SandboxSet (e.g., updating `spec.template`) **must be submitted as a patch, not a full-object update**. The controller continuously writes the warm pool's state (sandbox creation/deletion, available counts, revisions) back to the SandboxSet object; a full-object `Update` sends the entire object together with the `resourceVersion` read earlier, so it frequently fails with write conflicts (`409 Conflict`) and forces clients into repeated retries. A patch only carries the changed fields and does not conflict with the controller's writes.
+
+For example, update the sandbox image with `kubectl patch`:
+
+```bash
+kubectl patch sbs my-sandbox-pool --type merge -p \
+  '{"spec":{"template":{"spec":{"containers":[{"name":"sandbox","image":"my-registry/sandbox-image:v2"}]}}}}'
+```
+
+`kubectl edit` works in the same way: it computes the diff between the original object and your edits and submits it as a patch, so it is also safe on a busy SandboxSet:
+
+```bash
+kubectl edit sbs my-sandbox-pool -n default
+```
+
+In the editor, modify the fields under `spec.template` (e.g., the container image) and save; kubectl submits the change as a patch.
+
+:::caution
+Do not upgrade a SandboxSet through full-object `Update`/`Replace` operations (e.g., `kubectl replace`, or a full-object `Update` call in code). On a busy SandboxSet this causes frequent write conflicts.
+:::
+
+### Monitoring Progress
+
+Check the SandboxSet status to monitor the rolling update:
+
+```bash
+kubectl get sandboxset my-sandbox-pool -o wide
+```
+
+Example output:
+
+```
+NAME              REPLICAS   AVAILABLE   UPDATEDREPLICAS   UPDATEDAVAILABLEREPLICAS   UPDATEREVISION   AGE
+my-sandbox-pool   10         8           6                 5                          a1b2c3d4         30m
+```
+
+| Field | Description |
+|---|---|
+| `REPLICAS` | Total number of sandboxes (creating + available + running + paused) |
+| `AVAILABLE` | Number of sandboxes ready to be claimed |
+| `UPDATEDREPLICAS` | Number of sandboxes that have been updated to the latest revision |
+| `UPDATEDAVAILABLEREPLICAS` | Number of updated sandboxes that are available |
+| `UPDATEREVISION` | Hash of the current desired template version |
+
+The rolling update is complete when `UPDATEDAVAILABLEREPLICAS` equals the desired `REPLICAS` count.
+
+You can also inspect individual sandbox revisions:
+
+```bash
+kubectl get sandboxes -l agents.kruise.io/sandbox-template=my-sandbox-pool -o custom-columns=\
+NAME:.metadata.name,\
+PHASE:.status.phase,\
+REVISION:.status.updateRevision
+```
 
 ## Claiming and Replenishing Warm Sandboxes
 


### PR DESCRIPTION
## What this PR does

Updates the Kruise Agents documentation for warm pool management (EN + ZH):

### Warm Pool Management page

- Adds a **Scaling the Warm Pool** section, emphasizing that replica changes must go through the SandboxSet **`scale` subresource** (with `kubectl scale` examples and a caution against full-object updates), because the controller continuously writes the warm pool's state back to the SandboxSet object.
- Moves the **pre-warmed pool upgrade** content (How It Works, Configuration, `updateStrategy.maxUnavailable`, Monitoring Progress) here from the Upgrade Sandboxes page.
- Adds a **Use Patch, Not Full-Object Update** subsection: SandboxSet modifications must be submitted as patches (`kubectl patch` / `kubectl edit`), since full-object `Update`/`Replace` causes frequent `409 Conflict` write conflicts on busy SandboxSets.

### Upgrade Sandboxes page

- The SandboxSet section is reduced to a brief stub summarizing the rolling-update behavior and linking to the Warm Pool Management section. Claimed-sandbox (SandboxUpdateOps) content is untouched.

## Validation

- `git diff --check`: clean
- `npm run build`: succeeds with no warnings related to the changed pages
- EN/ZH counterparts updated together with matching structure; anchor links verified against Docusaurus slug rules
