### PR TITLE
docs(checkpoint): document checkpoint ID label

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/checkpoint.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/checkpoint.md
@@ -147,6 +147,20 @@ checkpoint-code-demo-02    Creating    10s
 $ kubectl get cp -l agents.kruise.io/sandbox-name=code-interpreter-28rvn
 ```
 
+E2B 快照请求进入 `Succeeded` 阶段后，sandbox-manager 还会尝试把底层驱动 ID 从 `status.checkpointId` 复制到
+`agents.kruise.io/checkpoint-id` label。通过该 label 可以直接找到对应的 Checkpoint，无需逐个检查资源状态：
+
+```shell
+$ kubectl get cp -n default -l agents.kruise.io/checkpoint-id=<checkpoint-id>
+```
+
+该 label 按尽力而为原则写入。即使 label 更新失败，Checkpoint 仍然可用，E2B API 也仍会返回其 snapshot ID。
+如果通过 label 没有查到结果，请直接检查 `status.checkpointId`：
+
+```shell
+$ kubectl get cp -n default -o custom-columns=NAME:.metadata.name,CHECKPOINT_ID:.status.checkpointId
+```
+
 </TabItem>
 <TabItem value="E2B" label="E2B SDK">
 

--- a/kruiseagents/user-manuals/checkpoint.md
+++ b/kruiseagents/user-manuals/checkpoint.md
@@ -162,6 +162,21 @@ through the E2B API; can be set manually on CRD-created ones):
 $ kubectl get cp -l agents.kruise.io/sandbox-name=code-interpreter-28rvn
 ```
 
+After an E2B snapshot request reaches `Succeeded`, sandbox-manager also attempts to copy the backing driver ID from
+`status.checkpointId` to the `agents.kruise.io/checkpoint-id` label. You can use this label to find the corresponding
+Checkpoint without inspecting every resource's status:
+
+```shell
+$ kubectl get cp -n default -l agents.kruise.io/checkpoint-id=<checkpoint-id>
+```
+
+This label is written on a best-effort basis. A Checkpoint remains usable and the E2B API still returns its snapshot ID
+if the label update fails. If the label query returns no result, inspect `status.checkpointId` directly:
+
+```shell
+$ kubectl get cp -n default -o custom-columns=NAME:.metadata.name,CHECKPOINT_ID:.status.checkpointId
+```
+
 </TabItem>
 <TabItem value="E2B" label="E2B SDK">
 


### PR DESCRIPTION
## Summary

- document the selectable agents.kruise.io/checkpoint-id label introduced by openkruise/agents#712
- clarify that sandbox-manager writes the label on a best-effort basis for successful E2B snapshot requests
- provide label-based lookup and status fallback commands in both English and Simplified Chinese

## Validation

- git diff --check
- npm run build