### PR TITLE
docs(kruiseagents): add PoolAutoscaler user manual

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/poolautoscaler.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/poolautoscaler.md
@@ -97,7 +97,7 @@ kubectl apply -f pool-autoscaler.yaml
 kubectl get poolautoscaler sandbox-pool-autoscaler -n default
 ```
 
-`minReplicas` 和 `maxReplicas` 始终生效，所有策略计算出的副本数都会被限制在这个范围内。`targetAvailable`、`tolerance` 和 `minReplicas` 的取值共同决定空闲预热池能否收缩到 `minReplicas`，配置规则见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。
+`minReplicas` 和 `maxReplicas` 始终生效，所有策略计算出的副本数都会被限制在这个范围内。`targetAvailable`、`tolerance` 和 `minReplicas` 的取值共同决定空闲预热池能否收缩到 `minReplicas`，配置规则见[容量策略参数调优指南](#容量策略参数调优指南)。
 
 ### 步骤三：使用 E2B 业务流量验证
 
@@ -288,12 +288,17 @@ spec:
 
 SandboxSet 的 `spec.scaleStrategy.maxUnavailable` 同时作为启动预算；未设置时默认为当前副本数（相当于 100%，即不限制并发扩容量）。注意它与 `updateStrategy.maxUnavailable`（滚动更新用，默认 20%）是不同字段。处于创建阶段的 Sandbox 按以下两类计数占用预算：
 
-- **Failed**：Ready condition 为 `False` 且 reason 为 `StartContainerFailed` 或 `PodCreateFailed`，即明确的启动失败（容器启动失败、镜像/配置错误、创建 API 失败等）。
-- **TimedOut**：长期停留在 Creating/ResourcePending 状态、创建时间超过 50 秒（内置的 Pending 超时阈值）仍未 Ready。
+- **Failed**：Ready condition 为 `False` 且 reason 为 `StartContainerFailed`、`PodCreateFailed` 或 `Unschedulable`，即明确的启动失败（容器启动失败、镜像/配置错误、创建 API 失败、调度失败如节点资源不足或底层调度错误等）。
+- **TimedOut**：长期停留在 Creating/ResourcePending 状态、创建时间超过 Pending 超时阈值（默认 50 秒）仍未 Ready。
 
 当 `Failed + TimedOut >= 启动预算` 时，SandboxSet 写入：
 
 ```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: sandbox-pool
+  namespace: default
 status:
   conditions:
     - type: ScalingLimited
@@ -348,7 +353,7 @@ SandboxSet 会自动重建新实例；若配置未修复，新实例仍会失败
 
 - **TimedOut 为主**：底层创建速度跟不上扩容节奏。可调小 SandboxSet 的 `scaleStrategy.maxUnavailable` 降低单批创建量，或联系集群管理员评估底层供给能力。
 
-## 容量策略参数与缩容可达性
+## 容量策略参数调优指南
 
 容量策略根据“目标值 + 容差”计算上下水位：
 
@@ -421,9 +426,9 @@ Cron 策略的校验规则（最多 20 条、name 唯一、五段合法 Cron 表
 | 字段 | 说明 |
 | --- | --- |
 | `spec.scaleTargetRef` | 待管理的 SandboxSet 引用；`kind` 必须为 `SandboxSet`，目标与 PoolAutoscaler 必须位于同一 namespace。 |
-| `spec.minReplicas` / `spec.maxReplicas` | 预热池副本下限和上限。`maxReplicas` 必须大于 0，`minReplicas` 不能大于 `maxReplicas`。容量策略需能将空闲预热池收缩到 `minReplicas`，取值约束见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。 |
-| `spec.capacityPolicy.targetAvailable` | 目标可用 Sandbox 数，可填绝对值或百分比，例如 `10`、`"60%"`。百分比以近期平均副本数为基准；使用百分比时必须设置 `minReplicas: 1` 或更大。取值需与 `tolerance`、`minReplicas` 共同满足缩容可达性规则，详见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。 |
-| `spec.capacityPolicy.tolerance` | 目标允许偏差，可填绝对值或百分比；未设置时默认为 `10%`。例如目标为 10、偏差为 2 时，低于 8 扩容、高于 12 缩容。解析方式与缩容可达性约束见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。 |
+| `spec.minReplicas` / `spec.maxReplicas` | 预热池副本下限和上限。`maxReplicas` 必须大于 0，`minReplicas` 不能大于 `maxReplicas`。容量策略需能将空闲预热池收缩到 `minReplicas`，取值约束见[容量策略参数调优指南](#容量策略参数调优指南)。 |
+| `spec.capacityPolicy.targetAvailable` | 目标可用 Sandbox 数，可填绝对值或百分比，例如 `10`、`"60%"`。百分比以近期平均副本数为基准；使用百分比时必须设置 `minReplicas: 1` 或更大。取值需与 `tolerance`、`minReplicas` 共同满足缩容可达性规则，详见[容量策略参数调优指南](#容量策略参数调优指南)。 |
+| `spec.capacityPolicy.tolerance` | 目标允许偏差，可填绝对值或百分比；未设置时默认为 `10%`。例如目标为 10、偏差为 2 时，低于 8 扩容、高于 12 缩容。解析方式与缩容可达性约束见[容量策略参数调优指南](#容量策略参数调优指南)。 |
 | `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds` | 连续扩容间隔。显式设置范围为 60 到 3600 秒，不设置时默认 60 秒。 |
 | `spec.capacityPolicy.scaleDown.stabilizationWindowSeconds` | 连续缩容间隔。显式设置范围为 60 到 3600 秒，默认 300 秒。 |
 | `spec.cronPolicies` | 定时策略列表，最多 20 条，Webhook 校验：`name` 必填且同一列表内唯一；`schedule` 必填且必须是合法的五段 Cron 表达式（分 时 日 月 星期）；`timeZone` 可选，设置时必须是合法时区（如 `Asia/Shanghai`）；`targetReplicas` 必须大于等于 0，超过 `maxReplicas` 时会被限制在 `maxReplicas`。 |

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/poolautoscaler.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/poolautoscaler.md
@@ -53,8 +53,6 @@ spec:
             limits:           # 资源上限；按实际运行时需要调整，过大浪费预热成本，过小影响启动
               cpu: "1"
               memory: 1Gi
-      nodeSelector:
-        type: virtual-kubelet  # ACS 场景固定调度到虚拟节点；自建集群请替换为实际节点选择器或删除
 ```
 
 :::note

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/poolautoscaler.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/poolautoscaler.md
@@ -1,0 +1,435 @@
+# 预热池自动扩缩容
+
+PoolAutoscaler 用于自动调整预热池的大小。它以未被领取的可用 Sandbox 数量和用户配置的 Cron 计划为依据，修改 SandboxSet 的 `spec.replicas`：可用 Sandbox 不足时补池，空闲 Sandbox 过多时缩池，也可以在已知高峰前提前预热。
+
+与基于 CPU、QPS 的自动伸缩不同，PoolAutoscaler 不采集业务指标，也不预测流量。它只管理预热池容量；Sandbox 被领取后的业务生命周期仍由 Agent Sandbox 服务处理。预热池的基础概念见[预热池管理](./warmpool-management.md)。
+
+## 背景与适用场景
+
+该能力适合以下场景：
+
+- **请求量随时变化**：例如用户通过 E2B API 创建、使用并释放 Sandbox，希望始终保留一定数量的可用实例以降低领取等待时间。
+- **高峰时间可预期**：例如工作日上班前、定时任务开始前或活动开始前，可在指定时间提前创建预热池。
+- **两类流量并存**：日常通过容量策略补池，并在已知高峰时由 Cron 策略指定预热规模。
+
+## 前提条件与使用限制
+
+使用前请确认：
+
+1. 已安装 `agent-sandbox-controller` 且版本支持 PoolAutoscaler：较新版本已默认启用，无需额外配置；旧版本需通过启动参数 `--feature-gates=PoolAutoscaler=true` 显式开启（安装方式见[安装](../installation.md)）。
+2. 已按[预热池管理](./warmpool-management.md)创建待管理的 SandboxSet，且 SandboxSet controller 正常运行。
+3. 同一 namespace 内，一个 SandboxSet 最多只能由一个 PoolAutoscaler 管理。
+4. PoolAutoscaler 至少配置一种策略：`capacityPolicy` 或 `cronPolicies`。
+
+PoolAutoscaler 仅修改目标 SandboxSet 的 `spec.replicas`。不要让 HPA、AHPA、脚本或其他控制器同时修改同一个字段；它也不直接创建或删除 Pod。
+
+## 场景一：按可用容量自动补池
+
+此场景适用于请求量难以准确预估、但希望稳定获得低领取延迟的业务。例如，业务通过 E2B API 不断创建 Sandbox、执行代码或命令、完成后释放 Sandbox。每次领取都会消耗预热池中的可用 Sandbox；容量策略据此补充未被领取的实例。
+
+### 步骤一：通过 SandboxSet 创建预热池
+
+已按[预热池管理](./warmpool-management.md)创建 SandboxSet 的用户可直接使用现有预热池。以下为最小示意，各字段含义见注释；请将标注“必须替换”的字段改为当前集群已验证的值。
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: sandbox-pool        # SandboxSet 名称，后续 PoolAutoscaler 通过此名称引用；可按需修改
+  namespace: default        # 部署命名空间；PoolAutoscaler 必须与它同 namespace
+spec:
+  replicas: 2               # 初始预热池大小；应用 PoolAutoscaler 后由其接管，可按成本设小一些
+  runtimes:
+    - name: agent-runtime   # 注入 envd 兼容运行时，步骤三的 E2B 代码执行/文件/命令能力依赖它
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: <your-agent-sandbox-image>   # 必须替换：集群内可拉取的 Agent Sandbox 运行时镜像
+          resources:
+            requests:         # 调度申请资源，影响预热池单实例成本和可放置的节点范围
+              cpu: "1"
+              memory: 1Gi
+            limits:           # 资源上限；按实际运行时需要调整，过大浪费预热成本，过小影响启动
+              cpu: "1"
+              memory: 1Gi
+      nodeSelector:
+        type: virtual-kubelet  # ACS 场景固定调度到虚拟节点；自建集群请替换为实际节点选择器或删除
+```
+
+:::note
+`runtimes: agent-runtime` 是步骤三 E2B 验证的必要条件（`run_code`、文件读写、命令执行均依赖注入的 envd 运行时）。运行时注入机制及其对 `sandbox-injection-config` ConfigMap 的依赖见[运行时注入](./runtime-injection.md)。
+:::
+
+```bash
+kubectl apply -f sandboxset.yaml
+kubectl get sandboxset sandbox-pool -n default
+```
+
+### 步骤二：配置 PoolAutoscaler
+
+以下策略按比例维护预热池：目标可用比例为 50%，使用默认容差 10%，近期平均可用比例低于 40% 时扩容，高于 60% 时缩容，两者之间不调整。百分比水位随池规模弹性伸缩，适合负载波动的业务。
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: PoolAutoscaler
+metadata:
+  name: sandbox-pool-autoscaler   # PoolAutoscaler 名称，仅用于标识和后续 kubectl 查询，可按需修改
+  namespace: default              # 必须与目标 SandboxSet 同 namespace
+spec:
+  scaleTargetRef:
+    apiVersion: agents.kruise.io/v1alpha1
+    kind: SandboxSet              # 仅支持 SandboxSet，不可修改
+    name: sandbox-pool            # 步骤一中创建的 SandboxSet 名称
+  minReplicas: 2                 # 预热池下限；百分比目标需满足缩容可达性，见下方说明
+  maxReplicas: 50                 # 预热池上限；按业务峰值并发量与集群容量设置
+  capacityPolicy:
+    targetAvailable: "50%"        # 目标可用（未被领取的）Sandbox 占副本数的比例，随池规模弹性伸缩
+    # tolerance 未设置时默认为 10%，与目标合并后形成 40%~60% 的不调整区间
+    scaleUp:
+      stabilizationWindowSeconds: 60    # 连续扩容最小间隔；设小可加快补池，但过小会导致扩容过于频繁
+    scaleDown:
+      stabilizationWindowSeconds: 300   # 连续缩容最小间隔；拉长可避免夜间流量波动频繁回收预热池
+```
+
+```bash
+kubectl apply -f pool-autoscaler.yaml
+kubectl get poolautoscaler sandbox-pool-autoscaler -n default
+```
+
+`minReplicas` 和 `maxReplicas` 始终生效，所有策略计算出的副本数都会被限制在这个范围内。`targetAvailable`、`tolerance` 和 `minReplicas` 的取值共同决定空闲预热池能否收缩到 `minReplicas`，配置规则见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。
+
+### 步骤三：使用 E2B 业务流量验证
+
+以下单文件脚本模拟真实业务流量：每个并发循环从预热池领取一个 Sandbox，执行代码、读写文件、执行命令，短暂持有后释放。预热池的扩缩容状态可通过步骤四的命令另行观察。
+
+准备工作：
+
+1. 本地已安装 Python 3.9+，并已配置目标集群的 kubeconfig（用于 kubectl 观察状态）。
+2. 安装 E2B SDK：`pip install e2b-code-interpreter`。
+3. 准备可访问的 E2B 服务域名、自签 CA 证书（如集群使用自签证书）及 API Key。
+
+将脚本保存为 `poolautoscaler-verify.py`：
+
+```python
+#!/usr/bin/env python3
+"""Generate E2B business traffic against a PoolAutoscaler-managed pool.
+
+Usage:
+  E2B_API_KEY='<api-key>' \
+  E2B_DOMAIN='<e2b-domain>' \
+  SSL_CERT_FILE='<ca-file>' \
+  python poolautoscaler-verify.py --template sandbox-pool
+"""
+import argparse, os, sys, threading, time
+from concurrent.futures import ThreadPoolExecutor
+
+stop = threading.Event()
+
+
+def business_loop(loop_id, template, hold, startup_timeout, deadline):
+    """One worker: claim a sandbox, run business calls, hold, then release."""
+    from e2b_code_interpreter import Sandbox
+    seq = 0
+    while time.monotonic() < deadline and not stop.is_set():
+        seq += 1
+        try:
+            sandbox = Sandbox.create(template=template, timeout=startup_timeout)
+            sandbox.run_code(f"print('loop={loop_id} seq={seq}')")
+            path = f"verify-{loop_id}-{seq}.txt"
+            content = f"loop={loop_id} seq={seq}\n"
+            sandbox.files.write(path, content)
+            assert sandbox.files.read(path) == content, "file content mismatch"
+            assert sandbox.commands.run(f"cat {path}").stdout == content
+            stop.wait(hold)          # simulate the business holding the sandbox
+            sandbox.kill()
+        except Exception as exc:
+            print(f"loop {loop_id} seq {seq} failed: "
+                  f"{type(exc).__name__}: {exc}", file=sys.stderr, flush=True)
+            stop.wait(5)             # back off before the next attempt
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default="sandbox-pool",
+                        help="SandboxSet name, i.e. the E2B template")
+    parser.add_argument("--concurrency", type=int, default=10,
+                        help="simultaneous business sandboxes; each consumes one pool slot")
+    parser.add_argument("--duration-seconds", type=int, default=300)
+    parser.add_argument("--hold-seconds", type=int, default=30,
+                        help="how long each loop holds its sandbox before releasing")
+    parser.add_argument("--startup-timeout", type=int, default=600,
+                        help="seconds to wait for each sandbox to start")
+    args = parser.parse_args()
+    if not os.getenv("E2B_API_KEY"):
+        parser.error("E2B_API_KEY must be set")
+
+    deadline = time.monotonic() + args.duration_seconds
+    print(f"load: {args.concurrency} loops x {args.duration_seconds}s, "
+          f"hold={args.hold_seconds}s (Ctrl+C stops early)", flush=True)
+    try:
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [pool.submit(business_loop, i, args.template,
+                                   args.hold_seconds, args.startup_timeout, deadline)
+                       for i in range(args.concurrency)]
+            for future in futures:
+                future.result()
+    except KeyboardInterrupt:
+        print("interrupted; waiting for in-flight sandboxes to settle...", flush=True)
+    finally:
+        stop.set()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+运行（另开一个终端执行步骤四的 `kubectl get ... -w` 可实时观察扩容）：
+
+```bash
+E2B_API_KEY='<api-key>' \
+E2B_DOMAIN='<e2b-domain>' \
+SSL_CERT_FILE='<ca-file>' \
+python poolautoscaler-verify.py \
+  --template sandbox-pool \
+  --concurrency 10 \
+  --duration-seconds 300 \
+  --hold-seconds 30
+```
+
+参数说明：
+
+- `--concurrency`：并发业务循环数。每个循环同时持有一个业务 Sandbox，等于从预热池领取的速率上限；调大后预热池消耗更快，PoolAutoscaler 扩容更明显。请确认 `maxReplicas` 大于该值，否则预热池无法补齐。
+- `--hold-seconds`：每个 Sandbox 的业务持有时长；越长则单位时间领取次数越少。
+- `--duration-seconds`：压测总时长，建议不小于扩容稳定窗口（默认 60 秒）的 3 倍，以观察至少两轮扩容。
+- `--startup-timeout`：单个 Sandbox 的创建超时时间，默认 600 秒；底层供给较慢时可调大。
+
+预期现象：压测期间用步骤四的命令观察，`currentCapacity.available` 持续下降、`desiredReplicas` 逐步抬升，说明容量策略检测到领取消耗并补充预热池。
+
+验证缩容（可选）：流量结束后，手动调低 `targetAvailable` 并观察预热池收敛：
+
+```bash
+kubectl patch poolautoscaler sandbox-pool-autoscaler -n default \
+  --type merge -p '{"spec":{"capacityPolicy":{"targetAvailable":"10%"}}}'
+kubectl get sandboxset sandbox-pool -n default -w
+```
+
+预热池应逐步缩至 `minReplicas`（示例为 2）。验证完成后，将 `targetAvailable` 改回原值即可。
+
+### 步骤四：观测扩缩容节奏与启动保护
+
+```bash
+kubectl get poolautoscaler sandbox-pool-autoscaler -n default -o yaml
+kubectl get sandboxset sandbox-pool -n default -o yaml
+kubectl describe poolautoscaler sandbox-pool-autoscaler -n default
+```
+
+重点查看 `status.currentReplicas`、`status.desiredReplicas`、`status.currentCapacity.available` 和 `status.conditions`。这些是最近一次调谐的观测值，可能与 SandboxSet 的实时状态存在短暂偏差。
+
+容量策略基于近期一段观察时间内的平均可用数量做决策，以平滑瞬时波动；首次扩缩容可以立即执行，后续按稳定窗口节奏执行：扩容默认间隔 60 秒，缩容默认间隔 300 秒，可通过 `stabilizationWindowSeconds` 调整（见[参数配置约束](#参数配置约束)）。扩容间隔的默认值已包含 Pending 超时的安全余量；配置更大的值时以配置值为准。
+
+当 SandboxSet 当前 generation 的 `ScalingLimited=True` 时，PoolAutoscaler 暂停继续扩容，避免在启动失败或 Pending 超时已耗尽预算时继续提高目标；缩容不受此限制。正在创建的 Sandbox 的创建并发由 SandboxSet 控制，PoolAutoscaler 不直接管理 Pod。限流的触发条件、恢复方式与排查步骤见[异常场景：扩容限流的触发与恢复](#异常场景扩容限流的触发与恢复)。
+
+调参建议：从小范围配置起步——较小的 `minReplicas`、`maxReplicas` 和较长的缩容间隔，结合启动成功率、领取延迟及预热成本逐步调整。若需临时观察或人工接管，可暂停自动扩缩容（恢复时设为 `false` 或删除该字段）：
+
+```bash
+kubectl patch poolautoscaler sandbox-pool-autoscaler -n default \
+  --type merge -p '{"spec":{"suspend":true}}'
+```
+
+### 步骤五（可选）：删除策略
+
+本步骤是可选操作。不再需要自动扩缩容时（例如业务下线或改为固定规模），可删除 PoolAutoscaler。删除后，SandboxSet 和现有 Sandbox 均会保留，SandboxSet 副本数维持在删除前的值，不会自动缩容；如需回收预热池，请再手动调整 `spec.replicas` 或删除 SandboxSet。
+
+```bash
+kubectl delete poolautoscaler sandbox-pool-autoscaler -n default
+```
+
+## 场景二：按时间提前预热
+
+此场景适用于高峰时间明确的业务，例如每天工作日 09:00 前会有大量用户创建开发环境。Cron 策略会在高峰开始前直接设定预热池目标，避免等到可用实例耗尽后再扩容。
+
+以下示例在工作日 08:30 将预热池设为 30 个副本，20:00 调整为 5 个副本：
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: PoolAutoscaler
+metadata:
+  name: sandbox-pool-schedule   # 仅用于标识，可按需修改
+  namespace: default            # 必须与目标 SandboxSet 同 namespace
+spec:
+  scaleTargetRef:
+    apiVersion: agents.kruise.io/v1alpha1
+    kind: SandboxSet            # 仅支持 SandboxSet
+    name: sandbox-pool          # 必须替换：已创建的 SandboxSet 名称
+  minReplicas: 2               # 平台下限；Cron 目标也会被限制在该范围内
+  maxReplicas: 50              # 平台上限；需覆盖所有 Cron 策略中最大的 targetReplicas
+  cronPolicies:
+    - name: weekday-peak        # 策略名，同一 PoolAutoscaler 内必须唯一
+      timeZone: Asia/Shanghai   # 不设置时默认使用 controller 所在时区，建议显式指定
+      schedule: "30 8 * * 1-5"  # 五段 Cron：分 时 日 月 星期；此处为工作日 08:30
+      targetReplicas: 30        # 触发时直接把预热池设为 30，需不超过 maxReplicas
+    - name: weekday-offpeak
+      timeZone: Asia/Shanghai
+      schedule: "0 20 * * 1-5"  # 工作日 20:00 缩回夜间规模
+      targetReplicas: 5
+```
+
+`cronPolicies` 使用五段 Cron 表达式：分、时、日、月、星期。未设置 `timeZone` 时使用 controller manager 进程的时区。Cron 触发时优先于容量策略，且不受容量策略稳定窗口限制；最终副本数仍受 `minReplicas` 和 `maxReplicas` 限制，扩容同样受 SandboxSet 启动保护限制（见[异常场景：扩容限流的触发与恢复](#异常场景扩容限流的触发与恢复)）。
+
+若同时配置容量策略，则未触发 Cron 时按容量策略补池，Cron 触发时以 Cron 目标为准。Cron 策略直接设定目标副本数，不受容量策略水位和缩容可达性规则约束，但仍会遵守扩容限流：Cron 抬升目标时若 SandboxSet 启动预算耗尽，同样会被阻塞并等待预算恢复。
+
+## 异常场景：扩容限流的触发与恢复
+
+扩容限流是 SandboxSet 的启动保护机制：当同一时间存在过多启动失败或长期 Pending 的 Sandbox 时，暂停进一步提高副本数，避免在异常状态下制造更多无法启动的实例。PoolAutoscaler 读取该信号并暂停扩容。
+
+### 限流的触发
+
+SandboxSet 的 `spec.scaleStrategy.maxUnavailable` 同时作为启动预算；未设置时默认为当前副本数（相当于 100%，即不限制并发扩容量）。注意它与 `updateStrategy.maxUnavailable`（滚动更新用，默认 20%）是不同字段。处于创建阶段的 Sandbox 按以下两类计数占用预算：
+
+- **Failed**：Ready condition 为 `False` 且 reason 为 `StartContainerFailed` 或 `PodCreateFailed`，即明确的启动失败（容器启动失败、镜像/配置错误、创建 API 失败等）。
+- **TimedOut**：长期停留在 Creating/ResourcePending 状态、创建时间超过 50 秒（内置的 Pending 超时阈值）仍未 Ready。
+
+当 `Failed + TimedOut >= 启动预算` 时，SandboxSet 写入：
+
+```yaml
+status:
+  conditions:
+    - type: ScalingLimited
+      status: "True"
+      reason: StartupBudgetExhausted
+      message: '2 of 2 startup slots are blocked: Timeout=1, Failed=1'
+```
+
+同时发出 Warning 级 `ScalingLimited` 事件。PoolAutoscaler 检测到该 condition 后：
+
+- 暂停扩容：`status.desiredReplicas` 不再抬升，即使可用数量已低于下水位；等待期间周期性发出 Normal 级 `ScaleBlocked` 事件。
+- 缩容不受影响：上水位触发的缩容照常执行。
+- 容错处理：仅当 SandboxSet 报告的是当前 generation 的显式 `True` 才阻塞；condition 缺失、陈旧或 `Unknown` 时按无信号处理，扩容照常，避免升级或首次调谐期间误阻塞。
+
+注意区分两个同名 condition：这里的 `ScalingLimited` 位于 **SandboxSet** status，表示启动预算耗尽；PoolAutoscaler 自身的 `ScalingLimited`（见 CRD 字段说明）表示期望副本数触及 `minReplicas`/`maxReplicas` 边界，两者含义不同。
+
+### 限流的恢复
+
+恢复不需要人工干预，满足任一条件后预算自动释放：
+
+- 失败的 Sandbox 被删除（手动删除或业务侧清理），或其 Pod 恢复 Running 且 Ready 变为 `True`；
+- Pending 超时的 Sandbox 完成启动进入 Running，或被删除。
+
+当 `Failed + TimedOut` 降回预算以下，SandboxSet 下一次调谐会将 `ScalingLimited` 改回 `False`，PoolAutoscaler 随即恢复扩容并继续补池。
+
+### 排查与应对
+
+```bash
+# 查看限流状态与 Timeout/Failed 计数
+kubectl get sandboxset sandbox-pool -n default -o jsonpath='{.status.conditions[?(@.type=="ScalingLimited")]}'
+kubectl describe sandboxset sandbox-pool -n default
+
+# 查看限流与阻塞事件
+kubectl get events -n default --field-selector involvedObject.name=sandbox-pool
+
+# 列出预热池中的 Sandbox 及其状态
+kubectl get sandbox -n default -l agents.kruise.io/sandbox-pool=sandbox-pool
+
+# 查看某个失败实例的 Ready condition 及具体原因
+kubectl get sandbox <name> -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
+```
+
+根据 `message` 中的计数定位主要问题：
+
+- **Failed 为主**：多为镜像拉取失败、资源配置错误或 quota 不足。查看失败 Sandbox 的 Ready condition message 确认具体原因，修正 SandboxSet 配置后删除失败实例：
+
+```bash
+kubectl delete sandbox <name> -n default
+```
+
+SandboxSet 会自动重建新实例；若配置未修复，新实例仍会失败并再次触发限流。
+
+- **TimedOut 为主**：底层创建速度跟不上扩容节奏。可调小 SandboxSet 的 `scaleStrategy.maxUnavailable` 降低单批创建量，或联系集群管理员评估底层供给能力。
+
+## 容量策略参数与缩容可达性
+
+容量策略根据“目标值 + 容差”计算上下水位：
+
+- `targetAvailable` 为绝对值（如 `10`）时：下水位 = 目标值 - 容差，上水位 = 目标值 + 容差。
+- `targetAvailable` 为百分比（如 `"60%"`）时：以近期平均副本数为基准，先将目标与容差的百分比合并，再向上取整，即下水位 = ceil(平均副本数 × (目标 - 容差)%)，上水位 = ceil(平均副本数 × (目标 + 容差)%)。
+- `tolerance` 未设置时默认为 `10%`。目标是百分比时按百分比合并；目标是绝对值时，默认容差为该目标值的 10% 向上取整（例如目标为 10 时容差为 1，目标为 15 时容差为 2）。
+
+平均可用数量低于下水位时扩容，并补足到目标值附近；高于上水位时缩容；位于两者之间时不调整。
+
+:::caution
+特别避免 `targetAvailable: "100%"`：可用数量最多等于副本数，永远不会严格高于上水位，因此无论容差如何配置，空闲预热池都永不缩容，只增不减。若确实希望池规模只增不减，再考虑使用 100% 目标。
+:::
+
+### 确保空闲预热池能收缩到 minReplicas
+
+容量策略应保证空闲预热池能够收缩到 `minReplicas`，否则预热池会停留在 `minReplicas` 之上，空闲资源无法回收到预期下限。判定方法是检查最后一步缩容：当预热池副本数为 `minReplicas + 1` 时，上水位必须不大于 `minReplicas`，这一步缩容才能触发。
+
+- 绝对值目标 `T` 与解析后的容差 `D`（含默认容差）：需满足 `T + D <= minReplicas`。满足时，空闲预热池的稳定规模就是 `minReplicas`。
+- 百分比目标 `p%` 与百分比容差 `q%`（含默认容差）：需满足 `p + q <= 100 × minReplicas / (minReplicas + 1)`。百分比水位随预热池缩小而降低，空闲时会逐步收敛到 `minReplicas`。
+- 百分比目标配绝对容差 `D`：在 `minReplicas + 1` 个副本处评估，需满足 `ceil((minReplicas + 1) × p%) + D <= minReplicas`。
+- 绝对目标 `T` 配百分比容差 `q%`：容差按 `ceil(T × q%)` 解析，需满足 `T + ceil(T × q%) <= minReplicas`。
+
+常见配置的效果如下：
+
+| minReplicas | targetAvailable | tolerance | 在 minReplicas+1 个副本处的上水位 | 效果 |
+| --- | --- | --- | --- | --- |
+| 1 | `"40%"` | 默认（`"10%"`） | 1 | 可从 2 个副本缩到 1 个 |
+| 1 | `"50%"` | 默认（`"10%"`） | 2 | 上水位为 2，停留在 2 个副本 |
+| 1 | `1` | `0` | 1 | 固定保底 1 个可用 Sandbox |
+| 1 | `1` | 默认（`"10%"`） | 2 | 默认容差将上水位抬高到 2，停留在 2 个副本 |
+| 2 | `"50%"` | 默认（`"10%"`） | 2 | 可从 3 个副本缩到 2 个（即场景一示例） |
+| 1 | `"100%"` | 任意（含 `0`） | `>= 副本数` | 可用数最多等于副本数，永不高于上水位，空闲池永不缩容 |
+| 4 | `"70%"` | `"10%"` | 4 | 可从 5 个副本缩到 4 个 |
+
+场景一演示了百分比目标的配置方式：水位随池规模弹性伸缩，适合负载波动的业务。需要固定规模的预热池时，可改用绝对值目标并设置 `tolerance: 0`，同时让 `minReplicas` 不小于目标值。无论哪种方式，都请按上述规则核对 `minReplicas`。
+
+如果预热池长期停留在高于 `minReplicas` 的规模且 `status.conditions` 无异常，通常是上述规则未满足：此时可调低 `targetAvailable` 或 `tolerance`，或调高 `minReplicas`，然后观察 `status.desiredReplicas` 与 `status.currentCapacity.available` 是否逐步收敛。
+
+## 参数配置约束
+
+创建或更新 PoolAutoscaler 时，Webhook 会校验以下规则；违反时请求被拒绝（HTTP 422）并返回具体原因。
+
+### 通用约束
+
+| 字段 | 约束 |
+| --- | --- |
+| `spec.scaleTargetRef.kind` | 仅支持 `SandboxSet`。 |
+| `spec.scaleTargetRef.name` | 必填，指向同 namespace 内已存在的 SandboxSet。 |
+| `spec.maxReplicas` | 必填且大于 0。 |
+| `spec.minReplicas` | 大于等于 0，且不能大于 `maxReplicas`。 |
+| `spec.capacityPolicy` / `spec.cronPolicies` | 至少配置一项，否则没有任何策略驱动扩缩容。 |
+| 同 namespace 内唯一性 | 一个 SandboxSet 只能由一个 PoolAutoscaler 管理。 |
+
+### 容量策略约束
+
+| 字段 | 约束 |
+| --- | --- |
+| `targetAvailable` | 绝对值必须 `>= 0` 且 `<= maxReplicas`（超出则目标永远无法达到）；百分比格式为 `"<number>%"`，数值范围 0 到 100。 |
+| `targetAvailable` 为百分比时 | 必须同时设置 `minReplicas >= 1`，否则空池时水位全部归 0，预热池无法自举。 |
+| `tolerance` | 格式约束同 `targetAvailable`；且必须**小于** `targetAvailable`（同为百分比或同为绝对值时可静态判定），否则下水位被钳制为 0，扩容永不触发。绝对目标配百分比容差时，容差百分比必须小于 100%。 |
+| `scaleUp.stabilizationWindowSeconds` | 不设置时默认 60 秒；显式设置必须在 60 到 3600 秒之间。 |
+| `scaleDown.stabilizationWindowSeconds` | 不设置时默认 300 秒；显式设置必须在 60 到 3600 秒之间。 |
+
+缩容可达性虽然不是当前版本的硬性校验，但配置不当会导致预热池无法缩至 `minReplicas`，建议按[确保空闲预热池能收缩到 minReplicas](#确保空闲预热池能收缩到-minreplicas)的规则核对。
+
+Cron 策略的校验规则（最多 20 条、name 唯一、五段合法 Cron 表达式、合法时区、`targetReplicas >= 0`）已在下方 CRD 字段说明中标注，此处不再重复。
+
+## CRD 字段说明
+
+| 字段 | 说明 |
+| --- | --- |
+| `spec.scaleTargetRef` | 待管理的 SandboxSet 引用；`kind` 必须为 `SandboxSet`，目标与 PoolAutoscaler 必须位于同一 namespace。 |
+| `spec.minReplicas` / `spec.maxReplicas` | 预热池副本下限和上限。`maxReplicas` 必须大于 0，`minReplicas` 不能大于 `maxReplicas`。容量策略需能将空闲预热池收缩到 `minReplicas`，取值约束见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。 |
+| `spec.capacityPolicy.targetAvailable` | 目标可用 Sandbox 数，可填绝对值或百分比，例如 `10`、`"60%"`。百分比以近期平均副本数为基准；使用百分比时必须设置 `minReplicas: 1` 或更大。取值需与 `tolerance`、`minReplicas` 共同满足缩容可达性规则，详见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。 |
+| `spec.capacityPolicy.tolerance` | 目标允许偏差，可填绝对值或百分比；未设置时默认为 `10%`。例如目标为 10、偏差为 2 时，低于 8 扩容、高于 12 缩容。解析方式与缩容可达性约束见[容量策略参数与缩容可达性](#容量策略参数与缩容可达性)。 |
+| `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds` | 连续扩容间隔。显式设置范围为 60 到 3600 秒，不设置时默认 60 秒。 |
+| `spec.capacityPolicy.scaleDown.stabilizationWindowSeconds` | 连续缩容间隔。显式设置范围为 60 到 3600 秒，默认 300 秒。 |
+| `spec.cronPolicies` | 定时策略列表，最多 20 条，Webhook 校验：`name` 必填且同一列表内唯一；`schedule` 必填且必须是合法的五段 Cron 表达式（分 时 日 月 星期）；`timeZone` 可选，设置时必须是合法时区（如 `Asia/Shanghai`）；`targetReplicas` 必须大于等于 0，超过 `maxReplicas` 时会被限制在 `maxReplicas`。 |
+| `spec.suspend` | 设为 `true` 后暂停后续自动扩缩容，不会删除已有 Sandbox。恢复时设为 `false` 或删除该字段。 |
+| `status.currentReplicas` | 目标 SandboxSet 最近观测到的当前副本数。 |
+| `status.desiredReplicas` | PoolAutoscaler 最近计算出的期望副本数。 |
+| `status.currentCapacity.available` | 最近观测到的可用 Sandbox 数量。 |
+| `status.conditions` | `ScalingActive` 表示控制器是否可用，`AbleToScale` 表示是否可计算和写入目标，`ScalingLimited` 表示是否受副本边界限制。 |
+| `status.appliedCronPolicies` | 每条 Cron 策略最近一次成功执行的时间。 |

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
@@ -54,8 +54,8 @@ spec:
 
 ```shell
 $ kubectl get sbs -n default
-NAME   REPLICAS   AVAILABLE   UPDATEREVISION   AGE
-demo   10         10          78dd8599cf       19m
+NAME   REPLICAS   AVAILABLE   UPDATEDREPLICAS   UPDATEDAVAILABLEREPLICAS   UPDATEREVISION   AGE
+demo   10         10          10                10                         78dd8599cf       19m
 ```
 
 ## 预热池扩缩容
@@ -80,7 +80,7 @@ kubectl scale sbs demo --replicas=5 -n default
 
 ### `scaleStrategy.maxUnavailable`
 
-该字段限制在 **扩容操作** 期间允许处于 **不可用** 状态（即处于 `creating` 状态）的沙箱最大数量。当你希望避免 Pod 创建突发增长对集群造成压力时，该字段非常有用。
+该字段限制扩容时**单批**创建的沙箱数量，并兼任 SandboxSet 扩容保护的**启动预算**。当你希望避免 Pod 创建突发增长对集群造成压力时，该字段非常有用。
 
 - 可以是绝对值（如 `5`）或百分比字符串（如 `"20%"`）。
 - 默认值：无限制（所有新沙箱同时创建）。
@@ -89,15 +89,15 @@ kubectl scale sbs demo --replicas=5 -n default
 spec:
   replicas: 20
   scaleStrategy:
-    # 在扩容期间，最多允许 5 个沙箱处于 creating 状态
+    # 扩容时每批最多创建 5 个沙箱
     maxUnavailable: 5
 ```
 
 :::tip
-扩容时，新创建的沙箱会按照该限制分批启动。例如，若 `maxUnavailable: 5`，从 0 扩容到 20，沙箱会以每批 5 个的方式创建——每一批只有在上一批变为 `available` 后才会开始创建。
+扩容时，新沙箱以不超过该限制的批次创建。控制器观测到上一批后即发出下一批；处于 `creating` 状态的沙箱不会阻塞后续批次，因此健康的预热池无需等待每批变为 `available` 即可持续扩容。
 :::
 
-除了控制物理创建节奏，该字段还兼任 SandboxSet 启动保护的**启动预算**：启动确定性失败的沙箱（Ready condition 为 `False` 且 reason 为 `StartContainerFailed`、`PodCreateFailed` 或 `Unschedulable`）、以及长期停留在 Creating/ResourcePending 且超过 Pending 超时阈值（默认 50 秒）的沙箱，都会占用该预算。当此类沙箱耗尽预算时，SandboxSet 会在 `status.conditions` 中上报 `ScalingLimited=True`（reason 为 `StartupBudgetExhausted`），[PoolAutoscaler](./poolautoscaler.md) 等控制器会暂停继续扩容，直到预算恢复。缩容不受该字段影响。
+只有确定性启动失败的沙箱才会占用启动预算：其 Ready condition 为 `False` 且 reason 为 `StartContainerFailed`、`PodCreateFailed` 或 `Unschedulable`，或长期停留在 Creating/ResourcePending 且超过 Pending 超时阈值（默认 50 秒）。健康的 `creating` 沙箱不消耗预算。当失败沙箱耗尽预算时，SandboxSet 会在 `status.conditions` 中上报 `ScalingLimited=True`（reason 为 `StartupBudgetExhausted`），[PoolAutoscaler](./poolautoscaler.md) 等控制器会暂停继续扩容，直到预算恢复。缩容不受该字段影响。
 
 该启动保护的触发条件、恢复方式与排查步骤，见 PoolAutoscaler 手册中的[异常场景：扩容限流的触发与恢复](./poolautoscaler.md#异常场景扩容限流的触发与恢复)。
 
@@ -201,7 +201,7 @@ my-sandbox-pool   10         8           6                 5                    
 
 | 字段 | 说明 |
 |---|---|
-| `REPLICAS` | 沙箱总数（创建中 + 可用 + 运行中 + 已暂停） |
+| `REPLICAS` | 预热池内沙箱总数（创建中 + 可用）；已被 Agent 领取的沙箱不计入 |
 | `AVAILABLE` | 可被认领的沙箱数量 |
 | `UPDATEDREPLICAS` | 已更新到最新版本的沙箱数量 |
 | `UPDATEDAVAILABLEREPLICAS` | 已更新且可用的沙箱数量 |

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/warmpool-management.md
@@ -97,6 +97,10 @@ spec:
 扩容时，新创建的沙箱会按照该限制分批启动。例如，若 `maxUnavailable: 5`，从 0 扩容到 20，沙箱会以每批 5 个的方式创建——每一批只有在上一批变为 `available` 后才会开始创建。
 :::
 
+除了控制物理创建节奏，该字段还兼任 SandboxSet 启动保护的**启动预算**：启动确定性失败的沙箱（Ready condition 为 `False` 且 reason 为 `StartContainerFailed`、`PodCreateFailed` 或 `Unschedulable`）、以及长期停留在 Creating/ResourcePending 且超过 Pending 超时阈值（默认 50 秒）的沙箱，都会占用该预算。当此类沙箱耗尽预算时，SandboxSet 会在 `status.conditions` 中上报 `ScalingLimited=True`（reason 为 `StartupBudgetExhausted`），[PoolAutoscaler](./poolautoscaler.md) 等控制器会暂停继续扩容，直到预算恢复。缩容不受该字段影响。
+
+该启动保护的触发条件、恢复方式与排查步骤，见 PoolAutoscaler 手册中的[异常场景：扩容限流的触发与恢复](./poolautoscaler.md#异常场景扩容限流的触发与恢复)。
+
 ## 升级预热池沙箱
 
 当你修改 SandboxSet 的 `spec.template` 字段时，控制器会检测到模板变更并对池中的沙箱执行 **滚动升级**。

--- a/kruiseagents/user-manuals/poolautoscaler.md
+++ b/kruiseagents/user-manuals/poolautoscaler.md
@@ -1,0 +1,435 @@
+# Warm Pool Autoscaling
+
+PoolAutoscaler automatically adjusts the size of a warm pool. Based on the number of unclaimed available Sandboxes and user-configured Cron schedules, it modifies the `spec.replicas` of a SandboxSet: replenishing the pool when available Sandboxes run low, shrinking it when too many sit idle, and pre-warming ahead of known peaks.
+
+Unlike CPU- or QPS-based autoscaling, PoolAutoscaler does not collect business metrics or predict traffic. It only manages warm pool capacity; the business lifecycle of a claimed Sandbox is still handled by the Agent Sandbox service. For warm pool fundamentals, see [Warm Pool Management](./warmpool-management.md).
+
+## Background and Use Cases
+
+This capability fits the following scenarios:
+
+- **Fluctuating request volume**: for example, users create, use, and release Sandboxes through the E2B API, and you always want a certain number of available instances on hand to reduce claim latency.
+- **Predictable peak hours**: for example, before workday mornings, scheduled tasks, or events, the pool can be pre-warmed at a specified time.
+- **Both traffic types coexist**: capacity policy replenishes the pool day to day, while Cron policies set the warm-up size for known peaks.
+
+## Prerequisites and Limitations
+
+Before you begin, confirm that:
+
+1. `agent-sandbox-controller` is installed at a version that supports PoolAutoscaler: newer versions enable it by default with no extra configuration; older versions require the startup flag `--feature-gates=PoolAutoscaler=true` (see [Installation](../installation.md)).
+2. A SandboxSet to manage has been created following [Warm Pool Management](./warmpool-management.md), and the SandboxSet controller is running normally.
+3. Within a namespace, a SandboxSet can be managed by at most one PoolAutoscaler.
+4. At least one policy is configured: `capacityPolicy` or `cronPolicies`.
+
+PoolAutoscaler only modifies `spec.replicas` of the target SandboxSet. Do not let HPA, AHPA, scripts, or other controllers write the same field concurrently; it does not create or delete Pods directly either.
+
+## Scenario 1: Replenish the Pool by Available Capacity
+
+This scenario suits businesses whose request volume is hard to predict but that need consistently low claim latency. For example, the business continuously creates Sandboxes through the E2B API, runs code or commands, and releases them when done. Each claim consumes an available Sandbox in the pool; the capacity policy replenishes unclaimed instances accordingly.
+
+### Step 1: Create the Warm Pool via SandboxSet
+
+Users who have already created a SandboxSet following [Warm Pool Management](./warmpool-management.md) can reuse it directly. The following is a minimal example; field meanings are in the comments. Replace the fields marked "MUST REPLACE" with values verified in your cluster.
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: sandbox-pool        # SandboxSet name, referenced by PoolAutoscaler later; change as needed
+  namespace: default        # deployment namespace; PoolAutoscaler must live in the same namespace
+spec:
+  replicas: 2               # initial pool size; taken over by PoolAutoscaler once applied, keep it small to save cost
+  runtimes:
+    - name: agent-runtime   # injects the envd-compatible runtime required by E2B code execution / files / commands
+  template:
+    spec:
+      containers:
+        - name: sandbox
+          image: <your-agent-sandbox-image>   # MUST REPLACE: an Agent Sandbox runtime image pullable in-cluster
+          resources:
+            requests:         # scheduling requests, affecting per-instance cost and placeable node range
+              cpu: "1"
+              memory: 1Gi
+            limits:           # resource limits; tune to your runtime — too large wastes warm-up cost, too small breaks startup
+              cpu: "1"
+              memory: 1Gi
+      nodeSelector:
+        type: virtual-kubelet  # ACS clusters pin scheduling to the virtual node; replace with your node selector or remove for self-managed clusters
+```
+
+:::note
+The `runtimes: agent-runtime` entry is required for the E2B verification in Step 3 (`run_code`, file reads/writes, command execution all rely on the injected envd runtime). For how runtime injection works and its dependency on the `sandbox-injection-config` ConfigMap, see [Runtime Injection](./runtime-injection.md).
+:::
+
+```bash
+kubectl apply -f sandboxset.yaml
+kubectl get sandboxset sandbox-pool -n default
+```
+
+### Step 2: Configure the PoolAutoscaler
+
+The following policy maintains the pool proportionally: the target availability ratio is 50% with the default 10% tolerance, so it scales up when the recent average availability drops below 40%, scales down above 60%, and makes no change in between. Percentage watermarks stretch with pool size, suiting workloads with fluctuating load.
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: PoolAutoscaler
+metadata:
+  name: sandbox-pool-autoscaler   # PoolAutoscaler name, for identification and later kubectl queries; change as needed
+  namespace: default              # must be in the same namespace as the target SandboxSet
+spec:
+  scaleTargetRef:
+    apiVersion: agents.kruise.io/v1alpha1
+    kind: SandboxSet              # only SandboxSet is supported
+    name: sandbox-pool            # the SandboxSet created in Step 1
+  minReplicas: 2                 # pool lower bound; percentage targets must satisfy scale-down reachability, see below
+  maxReplicas: 50                 # pool upper bound; set per peak concurrency and cluster capacity
+  capacityPolicy:
+    targetAvailable: "50%"        # target ratio of available (unclaimed) Sandboxes to replicas, stretching with pool size
+    # tolerance defaults to 10% when unset, combining with the target into a no-op zone of 40%~60%
+    scaleUp:
+      stabilizationWindowSeconds: 60    # minimum interval between consecutive scale-ups; smaller refills faster but scales more aggressively
+    scaleDown:
+      stabilizationWindowSeconds: 300   # minimum interval between consecutive scale-downs; longer avoids recycling the pool on nightly dips
+```
+
+```bash
+kubectl apply -f pool-autoscaler.yaml
+kubectl get poolautoscaler sandbox-pool-autoscaler -n default
+```
+
+`minReplicas` and `maxReplicas` are always enforced: every replica count computed by any policy is clamped into this range. The values of `targetAvailable`, `tolerance`, and `minReplicas` together determine whether an idle pool can shrink to `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability).
+
+### Step 3: Verify with E2B Business Traffic
+
+The following single-file script simulates real business traffic: each concurrent loop claims a Sandbox from the pool, runs code, writes and reads a file, runs a command, holds it briefly, then releases it. Pool scaling can be observed separately with the commands in Step 4.
+
+Preparation:
+
+1. Python 3.9+ is installed locally, and the target cluster's kubeconfig is configured (for observing state with kubectl).
+2. Install the E2B SDK: `pip install e2b-code-interpreter`.
+3. Prepare an accessible E2B service domain, a self-signed CA certificate (if the cluster uses one), and an API Key.
+
+Save the script as `poolautoscaler-verify.py`:
+
+```python
+#!/usr/bin/env python3
+"""Generate E2B business traffic against a PoolAutoscaler-managed pool.
+
+Usage:
+  E2B_API_KEY='<api-key>' \
+  E2B_DOMAIN='<e2b-domain>' \
+  SSL_CERT_FILE='<ca-file>' \
+  python poolautoscaler-verify.py --template sandbox-pool
+"""
+import argparse, os, sys, threading, time
+from concurrent.futures import ThreadPoolExecutor
+
+stop = threading.Event()
+
+
+def business_loop(loop_id, template, hold, startup_timeout, deadline):
+    """One worker: claim a sandbox, run business calls, hold, then release."""
+    from e2b_code_interpreter import Sandbox
+    seq = 0
+    while time.monotonic() < deadline and not stop.is_set():
+        seq += 1
+        try:
+            sandbox = Sandbox.create(template=template, timeout=startup_timeout)
+            sandbox.run_code(f"print('loop={loop_id} seq={seq}')")
+            path = f"verify-{loop_id}-{seq}.txt"
+            content = f"loop={loop_id} seq={seq}\n"
+            sandbox.files.write(path, content)
+            assert sandbox.files.read(path) == content, "file content mismatch"
+            assert sandbox.commands.run(f"cat {path}").stdout == content
+            stop.wait(hold)          # simulate the business holding the sandbox
+            sandbox.kill()
+        except Exception as exc:
+            print(f"loop {loop_id} seq {seq} failed: "
+                  f"{type(exc).__name__}: {exc}", file=sys.stderr, flush=True)
+            stop.wait(5)             # back off before the next attempt
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default="sandbox-pool",
+                        help="SandboxSet name, i.e. the E2B template")
+    parser.add_argument("--concurrency", type=int, default=10,
+                        help="simultaneous business sandboxes; each consumes one pool slot")
+    parser.add_argument("--duration-seconds", type=int, default=300)
+    parser.add_argument("--hold-seconds", type=int, default=30,
+                        help="how long each loop holds its sandbox before releasing")
+    parser.add_argument("--startup-timeout", type=int, default=600,
+                        help="seconds to wait for each sandbox to start")
+    args = parser.parse_args()
+    if not os.getenv("E2B_API_KEY"):
+        parser.error("E2B_API_KEY must be set")
+
+    deadline = time.monotonic() + args.duration_seconds
+    print(f"load: {args.concurrency} loops x {args.duration_seconds}s, "
+          f"hold={args.hold_seconds}s (Ctrl+C stops early)", flush=True)
+    try:
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [pool.submit(business_loop, i, args.template,
+                                   args.hold_seconds, args.startup_timeout, deadline)
+                       for i in range(args.concurrency)]
+            for future in futures:
+                future.result()
+    except KeyboardInterrupt:
+        print("interrupted; waiting for in-flight sandboxes to settle...", flush=True)
+    finally:
+        stop.set()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Run it (open another terminal with the `kubectl get ... -w` command from Step 4 to watch the scale-up live):
+
+```bash
+E2B_API_KEY='<api-key>' \
+E2B_DOMAIN='<e2b-domain>' \
+SSL_CERT_FILE='<ca-file>' \
+python poolautoscaler-verify.py \
+  --template sandbox-pool \
+  --concurrency 10 \
+  --duration-seconds 300 \
+  --hold-seconds 30
+```
+
+Parameter notes:
+
+- `--concurrency`: number of concurrent business loops. Each loop holds one business Sandbox at a time, capping the claim rate from the pool; a larger value drains the pool faster and makes the scale-up more visible. Make sure `maxReplicas` exceeds this value, otherwise the pool cannot refill.
+- `--hold-seconds`: how long each Sandbox is held for business work; longer means fewer claims per unit time.
+- `--duration-seconds`: total load duration; at least 3x the scale-up stabilization window (default 60 seconds) is recommended, to observe at least two rounds of scale-up.
+- `--startup-timeout`: per-Sandbox creation timeout, default 600 seconds; increase when the underlying supply is slow.
+
+Expected result: while the load runs, the commands in Step 4 show `currentCapacity.available` dropping and `desiredReplicas` climbing, which means the capacity policy detects claim-driven consumption and replenishes the pool.
+
+Verify scale-down (optional): after the load ends, manually lower `targetAvailable` and watch the pool converge:
+
+```bash
+kubectl patch poolautoscaler sandbox-pool-autoscaler -n default \
+  --type merge -p '{"spec":{"capacityPolicy":{"targetAvailable":"10%"}}}'
+kubectl get sandboxset sandbox-pool -n default -w
+```
+
+The pool should gradually shrink to `minReplicas` (2 in this example). Afterward, restore `targetAvailable` to its original value.
+
+### Step 4: Observe Scaling Rhythm and Startup Protection
+
+```bash
+kubectl get poolautoscaler sandbox-pool-autoscaler -n default -o yaml
+kubectl get sandboxset sandbox-pool -n default -o yaml
+kubectl describe poolautoscaler sandbox-pool-autoscaler -n default
+```
+
+Focus on `status.currentReplicas`, `status.desiredReplicas`, `status.currentCapacity.available`, and `status.conditions`. These are observations from the most recent reconcile and may briefly lag the SandboxSet's live state.
+
+The capacity policy decides based on the average availability over a recent observation period, smoothing out transient fluctuation. The first scale action executes immediately; subsequent actions follow the stabilization windows: scale-up defaults to a 60-second interval, scale-down to 300 seconds, both adjustable via `stabilizationWindowSeconds` (see [Parameter Validation Constraints](#parameter-validation-constraints)). The default scale-up interval already includes a safety margin for the pending timeout; when a larger value is configured, the configured value wins.
+
+When the SandboxSet's current-generation `ScalingLimited=True`, PoolAutoscaler pauses further scale-up, avoiding raising the target while the startup budget is exhausted by startup failures or pending timeouts; scale-down is unaffected. The creation concurrency of in-flight Sandboxes is controlled by the SandboxSet — PoolAutoscaler does not manage Pods directly. For trigger conditions, recovery, and troubleshooting of the limiter, see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](#failure-scenario-scale-up-throttling-trigger-and-recovery).
+
+Tuning advice: start small — lower `minReplicas`, `maxReplicas`, and longer scale-down intervals — then adjust gradually based on startup success rate, claim latency, and warm-up cost. To temporarily observe or take over manually, suspend autoscaling (resume by setting `false` or removing the field):
+
+```bash
+kubectl patch poolautoscaler sandbox-pool-autoscaler -n default \
+  --type merge -p '{"spec":{"suspend":true}}'
+```
+
+### Step 5 (Optional): Delete the Policy
+
+This step is optional. When autoscaling is no longer needed (for example, the business is decommissioned or switched to a fixed size), delete the PoolAutoscaler. The SandboxSet and existing Sandboxes are retained, and the SandboxSet replica count stays at the value before deletion with no further automatic scale-down; to reclaim the pool, manually adjust `spec.replicas` or delete the SandboxSet.
+
+```bash
+kubectl delete poolautoscaler sandbox-pool-autoscaler -n default
+```
+
+## Scenario 2: Pre-Warm on a Schedule
+
+This scenario suits businesses with well-known peak hours, for example heavy environment creation before 09:00 on workdays. A Cron policy sets the pool target directly ahead of the peak, instead of waiting for available instances to run out first.
+
+The following example sets the pool to 30 replicas at 08:30 on workdays and back to 5 at 20:00:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: PoolAutoscaler
+metadata:
+  name: sandbox-pool-schedule   # for identification only, change as needed
+  namespace: default            # must be in the same namespace as the target SandboxSet
+spec:
+  scaleTargetRef:
+    apiVersion: agents.kruise.io/v1alpha1
+    kind: SandboxSet            # only SandboxSet is supported
+    name: sandbox-pool          # MUST REPLACE: the created SandboxSet name
+  minReplicas: 2               # platform lower bound; Cron targets are clamped into this range too
+  maxReplicas: 50              # platform upper bound; must cover the largest targetReplicas across cron policies
+  cronPolicies:
+    - name: weekday-peak        # policy name, unique within the same PoolAutoscaler
+      timeZone: Asia/Shanghai   # defaults to the controller's timezone when unset; setting it explicitly is recommended
+      schedule: "30 8 * * 1-5"  # five-field cron: minute hour day month weekday; here 08:30 on workdays
+      targetReplicas: 30        # sets the pool directly to 30 when triggered; must not exceed maxReplicas
+    - name: weekday-offpeak
+      timeZone: Asia/Shanghai
+      schedule: "0 20 * * 1-5"  # shrink back to the night size at 20:00 on workdays
+      targetReplicas: 5
+```
+
+`cronPolicies` uses five-field cron expressions: minute, hour, day of month, month, day of week. When `timeZone` is unset, the controller manager's timezone applies. When triggered, Cron takes priority over the capacity policy and is not subject to the capacity stabilization windows; the final replica count is still clamped by `minReplicas` and `maxReplicas`, and scale-up is equally subject to the SandboxSet startup protection (see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](#failure-scenario-scale-up-throttling-trigger-and-recovery)).
+
+When both are configured, the capacity policy replenishes the pool while no Cron policy is triggered, and the Cron target wins when one triggers. Cron policies set the target replica count directly, unconstrained by capacity watermarks or scale-down reachability, but they still respect scale-up throttling: raising the target while the SandboxSet startup budget is exhausted is likewise blocked until the budget recovers.
+
+## Failure Scenario: Scale-Up Throttling, Trigger and Recovery
+
+Scale-up throttling is the SandboxSet's startup protection: when too many Sandboxes are failing to start or pending for a long time at once, further replica increases are paused to avoid creating more instances that cannot start in a broken state. PoolAutoscaler reads this signal and pauses scale-up.
+
+### What Triggers Throttling
+
+The SandboxSet's `spec.scaleStrategy.maxUnavailable` doubles as the startup budget; when unset it defaults to the current replica count (equivalent to 100%, i.e. no cap on concurrent scale-up). Note this is a different field from `updateStrategy.maxUnavailable` (for rolling updates, default 20%). Sandboxes in the creating phase occupy the budget through two counters:
+
+- **Failed**: Ready condition is `False` with reason `StartContainerFailed` or `PodCreateFailed` — a definitive startup failure (container startup failure, image/config errors, create API failures, etc.).
+- **TimedOut**: stuck in Creating/ResourcePending longer than 50 seconds (the built-in pending timeout) without becoming Ready.
+
+When `Failed + TimedOut >= startup budget`, the SandboxSet writes:
+
+```yaml
+status:
+  conditions:
+    - type: ScalingLimited
+      status: "True"
+      reason: StartupBudgetExhausted
+      message: '2 of 2 startup slots are blocked: Timeout=1, Failed=1'
+```
+
+and emits a Warning-level `ScalingLimited` event. On detecting this condition, PoolAutoscaler:
+
+- Pauses scale-up: `status.desiredReplicas` stops rising even when availability is below the lower watermark; while waiting, it periodically emits Normal-level `ScaleBlocked` events.
+- Leaves scale-down unaffected: upper-watermark scale-downs proceed as usual.
+- Fails open: only an explicit `True` reported against the SandboxSet's current generation blocks scaling; a missing, stale, or `Unknown` condition is treated as no signal so upgrades and first-time reconciles do not stall scale-up.
+
+Note the two same-named conditions: this `ScalingLimited` lives in the **SandboxSet** status and means the startup budget is exhausted; the PoolAutoscaler's own `ScalingLimited` (see the CRD field reference) means the desired replica count hit the `minReplicas`/`maxReplicas` bound — different semantics.
+
+### How Throttling Recovers
+
+Recovery needs no manual intervention; the budget frees automatically once either happens:
+
+- A failed Sandbox is deleted (manually or by the business side), or its Pod returns to Running with Ready flipped to `True`;
+- A pending-timed-out Sandbox finishes starting and enters Running, or is deleted.
+
+When `Failed + TimedOut` falls back below the budget, the SandboxSet's next reconcile flips `ScalingLimited` back to `False`, and PoolAutoscaler resumes scale-up and keeps replenishing the pool.
+
+### Troubleshooting
+
+```bash
+# Inspect the throttling state and Timeout/Failed counters
+kubectl get sandboxset sandbox-pool -n default -o jsonpath='{.status.conditions[?(@.type=="ScalingLimited")]}'
+kubectl describe sandboxset sandbox-pool -n default
+
+# List throttling and blocked events
+kubectl get events -n default --field-selector involvedObject.name=sandbox-pool
+
+# List Sandboxes in the pool and their status
+kubectl get sandbox -n default -l agents.kruise.io/sandbox-pool=sandbox-pool
+
+# Inspect the Ready condition of a failed instance for the concrete reason
+kubectl get sandbox <name> -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
+```
+
+Triage by the counters in `message`:
+
+- **Mostly Failed**: usually image pull failures, resource misconfiguration, or quota exhaustion. Check the failed Sandbox's Ready condition message for the concrete reason, fix the SandboxSet configuration, then delete the failed instance:
+
+```bash
+kubectl delete sandbox <name> -n default
+```
+
+The SandboxSet recreates a new instance automatically; if the configuration is not fixed, the new instance fails again and re-triggers throttling.
+
+- **Mostly TimedOut**: the underlying creation speed cannot keep up with the scaling rhythm. Lower the SandboxSet's `scaleStrategy.maxUnavailable` to reduce the per-batch creation volume, or contact the cluster administrator to evaluate underlying supply capacity.
+
+## Capacity Policy Parameters and Scale-Down Reachability
+
+The capacity policy computes lower and upper watermarks from "target + tolerance":
+
+- When `targetAvailable` is an absolute number (e.g. `10`): lower watermark = target − tolerance, upper watermark = target + tolerance.
+- When `targetAvailable` is a percentage (e.g. `"60%"`): based on the recent average replica count, the target and tolerance percentages are combined first and then rounded up, i.e. lower = ceil(average replicas × (target − tolerance)%), upper = ceil(average replicas × (target + tolerance)%).
+- When `tolerance` is unset it defaults to `10%`. For a percentage target it combines as percentages; for an absolute target the default tolerance is 10% of that target rounded up (e.g. tolerance is 1 for target 10, and 2 for target 15).
+
+When average availability drops below the lower watermark it scales up, refilling toward the target; above the upper watermark it scales down; in between it makes no change.
+
+:::caution
+Especially avoid `targetAvailable: "100%"`: availability can at most equal the replica count, so it never strictly exceeds the upper watermark. Regardless of tolerance (including 0), an idle pool never scales down — it only grows. Only use a 100% target if you deliberately want a grow-only pool.
+:::
+
+### Ensure an Idle Pool Can Shrink to minReplicas
+
+A capacity policy should guarantee that an idle pool shrinks to `minReplicas`; otherwise the pool settles above `minReplicas` and idle resources never get reclaimed to the intended floor. The test is the final scale-down step: at `minReplicas + 1` replicas, the upper watermark must be no greater than `minReplicas` for that step to trigger.
+
+- Absolute target `T` with resolved tolerance `D` (including the default): require `T + D <= minReplicas`. When satisfied, the idle pool's stable size is exactly `minReplicas`.
+- Percentage target `p%` with percentage tolerance `q%` (including the default): require `p + q <= 100 × minReplicas / (minReplicas + 1)`. Percentage watermarks shrink with the pool, converging to `minReplicas` when idle.
+- Percentage target with absolute tolerance `D`: evaluated at `minReplicas + 1` replicas, require `ceil((minReplicas + 1) × p%) + D <= minReplicas`.
+- Absolute target `T` with percentage tolerance `q%`: tolerance resolves as `ceil(T × q%)`, require `T + ceil(T × q%) <= minReplicas`.
+
+Common configurations and their effects:
+
+| minReplicas | targetAvailable | tolerance | Upper watermark at minReplicas+1 | Effect |
+| --- | --- | --- | --- | --- |
+| 1 | `"40%"` | default (`"10%"`) | 1 | Can shrink from 2 to 1 replica |
+| 1 | `"50%"` | default (`"10%"`) | 2 | Upper watermark is 2, settles at 2 replicas |
+| 1 | `1` | `0` | 1 | Fixed floor of 1 available Sandbox |
+| 1 | `1` | default (`"10%"`) | 2 | Default tolerance lifts the upper watermark to 2, settles at 2 replicas |
+| 2 | `"50%"` | default (`"10%"`) | 2 | Can shrink from 3 to 2 replicas (Scenario 1 example) |
+| 1 | `"100%"` | any (incl. `0`) | `>= replicas` | Availability at most equals replicas, never exceeds the upper watermark; idle pool never shrinks |
+| 4 | `"70%"` | `"10%"` | 4 | Can shrink from 5 to 4 replicas |
+
+Scenario 1 demonstrates the percentage-target style: watermarks stretch with pool size, fitting fluctuating workloads. For a fixed-size pool, switch to an absolute target with `tolerance: 0`, keeping `minReplicas` no smaller than the target. Either way, verify `minReplicas` against the rules above.
+
+If the pool sits above `minReplicas` for a long time and `status.conditions` shows no anomaly, the rules above are usually unmet: lower `targetAvailable` or `tolerance`, or raise `minReplicas`, then watch whether `status.desiredReplicas` and `status.currentCapacity.available` converge.
+
+## Parameter Validation Constraints
+
+On create or update, the webhook validates the following rules; violations are rejected (HTTP 422) with the concrete reason.
+
+### General Constraints
+
+| Field | Constraint |
+| --- | --- |
+| `spec.scaleTargetRef.kind` | Only `SandboxSet` is supported. |
+| `spec.scaleTargetRef.name` | Required, pointing to an existing SandboxSet in the same namespace. |
+| `spec.maxReplicas` | Required and must be greater than 0. |
+| `spec.minReplicas` | Must be `>= 0` and no greater than `maxReplicas`. |
+| `spec.capacityPolicy` / `spec.cronPolicies` | At least one must be configured; otherwise no policy drives scaling. |
+| Namespace uniqueness | A SandboxSet may be managed by only one PoolAutoscaler. |
+
+### Capacity Policy Constraints
+
+| Field | Constraint |
+| --- | --- |
+| `targetAvailable` | An absolute value must be `>= 0` and `<= maxReplicas` (beyond that the target can never be reached); a percentage must be of the form `"<number>%"` with the number in 0 to 100. |
+| Percentage `targetAvailable` | Must come with `minReplicas >= 1`; otherwise all watermarks resolve to 0 on an empty pool and the pool cannot bootstrap itself. |
+| `tolerance` | Same format constraints as `targetAvailable`; and must be **less than** `targetAvailable` (statically decidable when both are percentages or both are absolute), otherwise the lower watermark is clamped to 0 and scale-up never triggers. For an absolute target with a percentage tolerance, the tolerance percentage must be below 100%. |
+| `scaleUp.stabilizationWindowSeconds` | Defaults to 60 seconds when unset; explicit values must be between 60 and 3600 seconds. |
+| `scaleDown.stabilizationWindowSeconds` | Defaults to 300 seconds when unset; explicit values must be between 60 and 3600 seconds. |
+
+Scale-down reachability is not a hard validation in the current version, but a bad configuration leaves the pool unable to shrink to `minReplicas`; verify against the rules in [Ensure an Idle Pool Can Shrink to minReplicas](#ensure-an-idle-pool-can-shrink-to-minreplicas).
+
+Cron policy validation rules (at most 20 entries, unique names, valid five-field cron expressions, valid timezones, `targetReplicas >= 0`) are annotated in the CRD field reference below and are not repeated here.
+
+## CRD Field Reference
+
+| Field | Description |
+| --- | --- |
+| `spec.scaleTargetRef` | Reference to the managed SandboxSet; `kind` must be `SandboxSet`, and the target must be in the same namespace as the PoolAutoscaler. |
+| `spec.minReplicas` / `spec.maxReplicas` | Lower and upper bounds of the pool. `maxReplicas` must be greater than 0, and `minReplicas` must not exceed `maxReplicas`. The capacity policy must be able to shrink an idle pool to `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
+| `spec.capacityPolicy.targetAvailable` | Target available Sandbox count, as an absolute number or percentage, e.g. `10`, `"60%"`. Percentages are based on the recent average replica count; a percentage target requires `minReplicas: 1` or greater. Values must jointly satisfy scale-down reachability with `tolerance` and `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
+| `spec.capacityPolicy.tolerance` | Allowed deviation from the target, as an absolute number or percentage; defaults to `10%` when unset. For example, with target 10 and tolerance 2: scale up below 8, scale down above 12. Resolution rules and reachability constraints: see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
+| `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds` | Interval between consecutive scale-ups. Explicit values must be within 60 to 3600 seconds; defaults to 60 seconds. |
+| `spec.capacityPolicy.scaleDown.stabilizationWindowSeconds` | Interval between consecutive scale-downs. Explicit values must be within 60 to 3600 seconds; defaults to 300 seconds. |
+| `spec.cronPolicies` | List of scheduled policies, at most 20, webhook-validated: `name` is required and unique within the list; `schedule` is required and must be a valid five-field cron expression (minute hour day month weekday); `timeZone` is optional and must be a valid timezone (e.g. `Asia/Shanghai`) when set; `targetReplicas` must be `>= 0` and is clamped to `maxReplicas` when exceeded. |
+| `spec.suspend` | Set to `true` to suspend further autoscaling; existing Sandboxes are not deleted. Resume by setting `false` or removing the field. |
+| `status.currentReplicas` | The most recently observed replica count of the target SandboxSet. |
+| `status.desiredReplicas` | The most recently computed desired replica count. |
+| `status.currentCapacity.available` | The most recently observed available Sandbox count. |
+| `status.conditions` | `ScalingActive` reports whether the controller is active, `AbleToScale` whether a desired count can be computed and written, `ScalingLimited` whether the replica bound is hit. |
+| `status.appliedCronPolicies` | Last successful execution time of each cron policy. |

--- a/kruiseagents/user-manuals/poolautoscaler.md
+++ b/kruiseagents/user-manuals/poolautoscaler.md
@@ -97,7 +97,7 @@ kubectl apply -f pool-autoscaler.yaml
 kubectl get poolautoscaler sandbox-pool-autoscaler -n default
 ```
 
-`minReplicas` and `maxReplicas` are always enforced: every replica count computed by any policy is clamped into this range. The values of `targetAvailable`, `tolerance`, and `minReplicas` together determine whether an idle pool can shrink to `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability).
+`minReplicas` and `maxReplicas` are always enforced: every replica count computed by any policy is clamped into this range. The values of `targetAvailable`, `tolerance`, and `minReplicas` together determine whether an idle pool can shrink to `minReplicas`; see [Capacity Policy Parameters Tuning Guide](#capacity-policy-parameters-tuning-guide).
 
 ### Step 3: Verify with E2B Business Traffic
 
@@ -288,12 +288,17 @@ Scale-up throttling is the SandboxSet's startup protection: when too many Sandbo
 
 The SandboxSet's `spec.scaleStrategy.maxUnavailable` doubles as the startup budget; when unset it defaults to the current replica count (equivalent to 100%, i.e. no cap on concurrent scale-up). Note this is a different field from `updateStrategy.maxUnavailable` (for rolling updates, default 20%). Sandboxes in the creating phase occupy the budget through two counters:
 
-- **Failed**: Ready condition is `False` with reason `StartContainerFailed` or `PodCreateFailed` — a definitive startup failure (container startup failure, image/config errors, create API failures, etc.).
-- **TimedOut**: stuck in Creating/ResourcePending longer than 50 seconds (the built-in pending timeout) without becoming Ready.
+- **Failed**: Ready condition is `False` with reason `StartContainerFailed`, `PodCreateFailed`, or `Unschedulable` — a definitive startup failure (container startup failure, image/config errors, create API failures, scheduling failures such as insufficient node capacity or provider schedule errors, etc.).
+- **TimedOut**: stuck in Creating/ResourcePending longer than the pending timeout (default 50 seconds) without becoming Ready.
 
 When `Failed + TimedOut >= startup budget`, the SandboxSet writes:
 
 ```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: sandbox-pool
+  namespace: default
 status:
   conditions:
     - type: ScalingLimited
@@ -348,7 +353,7 @@ The SandboxSet recreates a new instance automatically; if the configuration is n
 
 - **Mostly TimedOut**: the underlying creation speed cannot keep up with the scaling rhythm. Lower the SandboxSet's `scaleStrategy.maxUnavailable` to reduce the per-batch creation volume, or contact the cluster administrator to evaluate underlying supply capacity.
 
-## Capacity Policy Parameters and Scale-Down Reachability
+## Capacity Policy Parameters Tuning Guide
 
 The capacity policy computes lower and upper watermarks from "target + tolerance":
 
@@ -421,9 +426,9 @@ Cron policy validation rules (at most 20 entries, unique names, valid five-field
 | Field | Description |
 | --- | --- |
 | `spec.scaleTargetRef` | Reference to the managed SandboxSet; `kind` must be `SandboxSet`, and the target must be in the same namespace as the PoolAutoscaler. |
-| `spec.minReplicas` / `spec.maxReplicas` | Lower and upper bounds of the pool. `maxReplicas` must be greater than 0, and `minReplicas` must not exceed `maxReplicas`. The capacity policy must be able to shrink an idle pool to `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
-| `spec.capacityPolicy.targetAvailable` | Target available Sandbox count, as an absolute number or percentage, e.g. `10`, `"60%"`. Percentages are based on the recent average replica count; a percentage target requires `minReplicas: 1` or greater. Values must jointly satisfy scale-down reachability with `tolerance` and `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
-| `spec.capacityPolicy.tolerance` | Allowed deviation from the target, as an absolute number or percentage; defaults to `10%` when unset. For example, with target 10 and tolerance 2: scale up below 8, scale down above 12. Resolution rules and reachability constraints: see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
+| `spec.minReplicas` / `spec.maxReplicas` | Lower and upper bounds of the pool. `maxReplicas` must be greater than 0, and `minReplicas` must not exceed `maxReplicas`. The capacity policy must be able to shrink an idle pool to `minReplicas`; see [Capacity Policy Parameters Tuning Guide](#capacity-policy-parameters-tuning-guide). |
+| `spec.capacityPolicy.targetAvailable` | Target available Sandbox count, as an absolute number or percentage, e.g. `10`, `"60%"`. Percentages are based on the recent average replica count; a percentage target requires `minReplicas: 1` or greater. Values must jointly satisfy scale-down reachability with `tolerance` and `minReplicas`; see [Capacity Policy Parameters Tuning Guide](#capacity-policy-parameters-tuning-guide). |
+| `spec.capacityPolicy.tolerance` | Allowed deviation from the target, as an absolute number or percentage; defaults to `10%` when unset. For example, with target 10 and tolerance 2: scale up below 8, scale down above 12. Resolution rules and reachability constraints: see [Capacity Policy Parameters Tuning Guide](#capacity-policy-parameters-tuning-guide). |
 | `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds` | Interval between consecutive scale-ups. Explicit values must be within 60 to 3600 seconds; defaults to 60 seconds. |
 | `spec.capacityPolicy.scaleDown.stabilizationWindowSeconds` | Interval between consecutive scale-downs. Explicit values must be within 60 to 3600 seconds; defaults to 300 seconds. |
 | `spec.cronPolicies` | List of scheduled policies, at most 20, webhook-validated: `name` is required and unique within the list; `schedule` is required and must be a valid five-field cron expression (minute hour day month weekday); `timeZone` is optional and must be a valid timezone (e.g. `Asia/Shanghai`) when set; `targetReplicas` must be `>= 0` and is clamped to `maxReplicas` when exceeded. |

--- a/kruiseagents/user-manuals/poolautoscaler.md
+++ b/kruiseagents/user-manuals/poolautoscaler.md
@@ -1,31 +1,31 @@
 # Warm Pool Autoscaling
 
-PoolAutoscaler automatically adjusts the size of a warm pool. Based on the number of unclaimed available Sandboxes and user-configured Cron schedules, it modifies the `spec.replicas` of a SandboxSet: replenishing the pool when available Sandboxes run low, shrinking it when too many sit idle, and pre-warming ahead of known peaks.
+PoolAutoscaler automatically adjusts the size of a warm pool. Based on the number of unclaimed Sandboxes and user-configured Cron schedules, it modifies the `spec.replicas` of a SandboxSet: replenishing the pool when available Sandboxes run low, shrinking it when too many sit idle, and pre-warming ahead of known peaks.
 
 Unlike CPU- or QPS-based autoscaling, PoolAutoscaler does not collect business metrics or predict traffic. It only manages warm pool capacity; the business lifecycle of a claimed Sandbox is still handled by the Agent Sandbox service. For warm pool fundamentals, see [Warm Pool Management](./warmpool-management.md).
 
 ## Background and Use Cases
 
-This capability fits the following scenarios:
+This capability is suited to the following scenarios:
 
 - **Fluctuating request volume**: for example, users create, use, and release Sandboxes through the E2B API, and you always want a certain number of available instances on hand to reduce claim latency.
-- **Predictable peak hours**: for example, before workday mornings, scheduled tasks, or events, the pool can be pre-warmed at a specified time.
-- **Both traffic types coexist**: capacity policy replenishes the pool day to day, while Cron policies set the warm-up size for known peaks.
+- **Predictable peak hours**: for example, ahead of weekday mornings, scheduled tasks, or events, the pool can be pre-warmed at a specified time.
+- **Both traffic types coexist**: capacity policy replenishes the pool day-to-day, while Cron policies set the warm-up target for known peaks.
 
 ## Prerequisites and Limitations
 
 Before you begin, confirm that:
 
 1. `agent-sandbox-controller` is installed at a version that supports PoolAutoscaler: newer versions enable it by default with no extra configuration; older versions require the startup flag `--feature-gates=PoolAutoscaler=true` (see [Installation](../installation.md)).
-2. A SandboxSet to manage has been created following [Warm Pool Management](./warmpool-management.md), and the SandboxSet controller is running normally.
+2. A target SandboxSet has been created following [Warm Pool Management](./warmpool-management.md), and the SandboxSet controller is running normally.
 3. Within a namespace, a SandboxSet can be managed by at most one PoolAutoscaler.
 4. At least one policy is configured: `capacityPolicy` or `cronPolicies`.
 
-PoolAutoscaler only modifies `spec.replicas` of the target SandboxSet. Do not let HPA, AHPA, scripts, or other controllers write the same field concurrently; it does not create or delete Pods directly either.
+PoolAutoscaler only modifies `spec.replicas` of the target SandboxSet. Do not let HPA, AHPA, scripts, or other controllers write the same field concurrently. PoolAutoscaler also does not create or delete Pods directly.
 
 ## Scenario 1: Replenish the Pool by Available Capacity
 
-This scenario suits businesses whose request volume is hard to predict but that need consistently low claim latency. For example, the business continuously creates Sandboxes through the E2B API, runs code or commands, and releases them when done. Each claim consumes an available Sandbox in the pool; the capacity policy replenishes unclaimed instances accordingly.
+This scenario suits businesses whose request volume is hard to predict but that need consistently low claim latency. For example, the business continuously creates Sandboxes through the E2B API, runs code or commands, and releases them when done. Each claim consumes an available Sandbox in the pool; the capacity policy replenishes the pool accordingly.
 
 ### Step 1: Create the Warm Pool via SandboxSet
 
@@ -38,23 +38,21 @@ metadata:
   name: sandbox-pool        # SandboxSet name, referenced by PoolAutoscaler later; change as needed
   namespace: default        # deployment namespace; PoolAutoscaler must live in the same namespace
 spec:
-  replicas: 2               # initial pool size; taken over by PoolAutoscaler once applied, keep it small to save cost
+  replicas: 2               # initial pool size; the PoolAutoscaler takes over once applied, so keep it small to reduce cost
   runtimes:
     - name: agent-runtime   # injects the envd-compatible runtime required by E2B code execution / files / commands
   template:
     spec:
       containers:
         - name: sandbox
-          image: <your-agent-sandbox-image>   # MUST REPLACE: an Agent Sandbox runtime image pullable in-cluster
+          image: <your-agent-sandbox-image>   # MUST REPLACE: an Agent Sandbox runtime image that can be pulled in-cluster
           resources:
-            requests:         # scheduling requests, affecting per-instance cost and placeable node range
+            requests:         # scheduling requests, affecting per-instance cost and schedulable node range
               cpu: "1"
               memory: 1Gi
-            limits:           # resource limits; tune to your runtime — too large wastes warm-up cost, too small breaks startup
+            limits:           # resource limits; tune to your runtime — too large wastes warm-up cost, too small causes startup to fail
               cpu: "1"
               memory: 1Gi
-      nodeSelector:
-        type: virtual-kubelet  # ACS clusters pin scheduling to the virtual node; replace with your node selector or remove for self-managed clusters
 ```
 
 :::note
@@ -68,7 +66,7 @@ kubectl get sandboxset sandbox-pool -n default
 
 ### Step 2: Configure the PoolAutoscaler
 
-The following policy maintains the pool proportionally: the target availability ratio is 50% with the default 10% tolerance, so it scales up when the recent average availability drops below 40%, scales down above 60%, and makes no change in between. Percentage watermarks stretch with pool size, suiting workloads with fluctuating load.
+The following policy maintains the pool proportionally: the target availability ratio is 50% with the default 10% tolerance, so it scales up when the recent average availability drops below 40%, scales down above 60%, and makes no change in between. Percentage watermarks stretch with pool size, suited to fluctuating workloads.
 
 ```yaml
 apiVersion: agents.kruise.io/v1alpha1
@@ -82,14 +80,14 @@ spec:
     kind: SandboxSet              # only SandboxSet is supported
     name: sandbox-pool            # the SandboxSet created in Step 1
   minReplicas: 2                 # pool lower bound; percentage targets must satisfy scale-down reachability, see below
-  maxReplicas: 50                 # pool upper bound; set per peak concurrency and cluster capacity
+  maxReplicas: 50                 # pool upper bound; set based on peak concurrency and cluster capacity
   capacityPolicy:
     targetAvailable: "50%"        # target ratio of available (unclaimed) Sandboxes to replicas, stretching with pool size
-    # tolerance defaults to 10% when unset, combining with the target into a no-op zone of 40%~60%
+    # tolerance defaults to 10% when unset, combining with the target into a no-action range of 40% to 60%
     scaleUp:
-      stabilizationWindowSeconds: 60    # minimum interval between consecutive scale-ups; smaller refills faster but scales more aggressively
+      stabilizationWindowSeconds: 60    # minimum interval between consecutive scale-ups; a smaller value refills the pool faster but scales more aggressively
     scaleDown:
-      stabilizationWindowSeconds: 300   # minimum interval between consecutive scale-downs; longer avoids recycling the pool on nightly dips
+      stabilizationWindowSeconds: 300   # minimum interval between consecutive scale-downs; a longer value avoids recycling the pool during nightly dips
 ```
 
 ```bash
@@ -97,7 +95,7 @@ kubectl apply -f pool-autoscaler.yaml
 kubectl get poolautoscaler sandbox-pool-autoscaler -n default
 ```
 
-`minReplicas` and `maxReplicas` are always enforced: every replica count computed by any policy is clamped into this range. The values of `targetAvailable`, `tolerance`, and `minReplicas` together determine whether an idle pool can shrink to `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability).
+`minReplicas` and `maxReplicas` are always enforced: every replica count computed by any policy is clamped to this range. The values of `targetAvailable`, `tolerance`, and `minReplicas` together determine whether an idle pool can shrink to `minReplicas`; see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability).
 
 ### Step 3: Verify with E2B Business Traffic
 
@@ -225,13 +223,13 @@ kubectl get sandboxset sandbox-pool -n default -o yaml
 kubectl describe poolautoscaler sandbox-pool-autoscaler -n default
 ```
 
-Focus on `status.currentReplicas`, `status.desiredReplicas`, `status.currentCapacity.available`, and `status.conditions`. These are observations from the most recent reconcile and may briefly lag the SandboxSet's live state.
+Focus on `status.currentReplicas`, `status.desiredReplicas`, `status.currentCapacity.available`, and `status.conditions`. These reflect the most recent reconciliation and may briefly lag the SandboxSet's live state.
 
 The capacity policy decides based on the average availability over a recent observation period, smoothing out transient fluctuation. The first scale action executes immediately; subsequent actions follow the stabilization windows: scale-up defaults to a 60-second interval, scale-down to 300 seconds, both adjustable via `stabilizationWindowSeconds` (see [Parameter Validation Constraints](#parameter-validation-constraints)). The default scale-up interval already includes a safety margin for the pending timeout; when a larger value is configured, the configured value wins.
 
-When the SandboxSet's current-generation `ScalingLimited=True`, PoolAutoscaler pauses further scale-up, avoiding raising the target while the startup budget is exhausted by startup failures or pending timeouts; scale-down is unaffected. The creation concurrency of in-flight Sandboxes is controlled by the SandboxSet — PoolAutoscaler does not manage Pods directly. For trigger conditions, recovery, and troubleshooting of the limiter, see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](#failure-scenario-scale-up-throttling-trigger-and-recovery).
+When the SandboxSet's current-generation `ScalingLimited` condition is `True`, PoolAutoscaler pauses further scale-up. This avoids raising the target while the startup budget is exhausted due to startup failures or pending timeouts. Scale-down is unaffected. The creation concurrency of in-flight Sandboxes is controlled by the SandboxSet — PoolAutoscaler does not manage Pods directly. For trigger conditions, recovery, and troubleshooting of the limiter, see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](#failure-scenario-scale-up-throttling-trigger-and-recovery).
 
-Tuning advice: start small — lower `minReplicas`, `maxReplicas`, and longer scale-down intervals — then adjust gradually based on startup success rate, claim latency, and warm-up cost. To temporarily observe or take over manually, suspend autoscaling (resume by setting `false` or removing the field):
+Tuning advice: start small — use lower `minReplicas` and `maxReplicas` and a longer scale-down interval — then adjust gradually based on startup success rate, claim latency, and warm-up cost. To temporarily observe or take manual control, suspend autoscaling (resume by setting `false` or removing the field):
 
 ```bash
 kubectl patch poolautoscaler sandbox-pool-autoscaler -n default \
@@ -248,7 +246,7 @@ kubectl delete poolautoscaler sandbox-pool-autoscaler -n default
 
 ## Scenario 2: Pre-Warm on a Schedule
 
-This scenario suits businesses with well-known peak hours, for example heavy environment creation before 09:00 on workdays. A Cron policy sets the pool target directly ahead of the peak, instead of waiting for available instances to run out first.
+This scenario suits businesses with well-known peak hours, for example heavy sandbox creation ahead of 09:00 on workdays. A Cron policy sets the pool target directly ahead of the peak, instead of waiting for available instances to be depleted.
 
 The following example sets the pool to 30 replicas at 08:30 on workdays and back to 5 at 20:00:
 
@@ -263,7 +261,7 @@ spec:
     apiVersion: agents.kruise.io/v1alpha1
     kind: SandboxSet            # only SandboxSet is supported
     name: sandbox-pool          # MUST REPLACE: the created SandboxSet name
-  minReplicas: 2               # platform lower bound; Cron targets are clamped into this range too
+  minReplicas: 2               # platform lower bound; Cron targets are clamped to this range too
   maxReplicas: 50              # platform upper bound; must cover the largest targetReplicas across cron policies
   cronPolicies:
     - name: weekday-peak        # policy name, unique within the same PoolAutoscaler
@@ -276,19 +274,19 @@ spec:
       targetReplicas: 5
 ```
 
-`cronPolicies` uses five-field cron expressions: minute, hour, day of month, month, day of week. When `timeZone` is unset, the controller manager's timezone applies. When triggered, Cron takes priority over the capacity policy and is not subject to the capacity stabilization windows; the final replica count is still clamped by `minReplicas` and `maxReplicas`, and scale-up is equally subject to the SandboxSet startup protection (see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](#failure-scenario-scale-up-throttling-trigger-and-recovery)).
+The `cronPolicies` field uses five-field cron expressions: minute, hour, day of month, month, day of week. When `timeZone` is unset, the controller manager's timezone applies. When triggered, Cron takes priority over the capacity policy and is not subject to the capacity stabilization windows; the final replica count is still clamped to `minReplicas` and `maxReplicas`, and scale-up is also subject to the SandboxSet startup protection (see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](#failure-scenario-scale-up-throttling-trigger-and-recovery)).
 
-When both are configured, the capacity policy replenishes the pool while no Cron policy is triggered, and the Cron target wins when one triggers. Cron policies set the target replica count directly, unconstrained by capacity watermarks or scale-down reachability, but they still respect scale-up throttling: raising the target while the SandboxSet startup budget is exhausted is likewise blocked until the budget recovers.
+When both are configured, the capacity policy replenishes the pool while no Cron policy is triggered, and the Cron target wins when one triggers. Cron policies set the target replica count directly, unconstrained by capacity watermarks or scale-down reachability, but they still respect scale-up throttling: raising the target while the SandboxSet startup budget is exhausted is also blocked until the budget recovers.
 
 ## Failure Scenario: Scale-Up Throttling, Trigger and Recovery
 
-Scale-up throttling is the SandboxSet's startup protection: when too many Sandboxes are failing to start or pending for a long time at once, further replica increases are paused to avoid creating more instances that cannot start in a broken state. PoolAutoscaler reads this signal and pauses scale-up.
+Scale-up throttling is the SandboxSet's startup protection: when too many Sandboxes are failing to start or pending for too long simultaneously, further replica increases are paused to avoid creating more instances that cannot start in a broken state. PoolAutoscaler reads this signal and pauses scale-up.
 
 ### What Triggers Throttling
 
-The SandboxSet's `spec.scaleStrategy.maxUnavailable` doubles as the startup budget; when unset it defaults to the current replica count (equivalent to 100%, i.e. no cap on concurrent scale-up). Note this is a different field from `updateStrategy.maxUnavailable` (for rolling updates, default 20%). Sandboxes in the creating phase occupy the budget through two counters:
+The SandboxSet's `spec.scaleStrategy.maxUnavailable` doubles as the startup budget; when unset it defaults to the current replica count (equivalent to 100%, i.e. no cap on concurrent scale-up). Note that this is a different field from `updateStrategy.maxUnavailable` (for rolling updates, default 20%). Sandboxes in the Creating phase are counted against the budget using two counters:
 
-- **Failed**: Ready condition is `False` with reason `StartContainerFailed` or `PodCreateFailed` — a definitive startup failure (container startup failure, image/config errors, create API failures, etc.).
+- **Failed**: Ready condition is `False` with reason `StartContainerFailed` or `PodCreateFailed` — a definitive startup failure (container startup failure, image/config errors, Pod creation API failures, etc.).
 - **TimedOut**: stuck in Creating/ResourcePending longer than 50 seconds (the built-in pending timeout) without becoming Ready.
 
 When `Failed + TimedOut >= startup budget`, the SandboxSet writes:
@@ -306,18 +304,18 @@ and emits a Warning-level `ScalingLimited` event. On detecting this condition, P
 
 - Pauses scale-up: `status.desiredReplicas` stops rising even when availability is below the lower watermark; while waiting, it periodically emits Normal-level `ScaleBlocked` events.
 - Leaves scale-down unaffected: upper-watermark scale-downs proceed as usual.
-- Fails open: only an explicit `True` reported against the SandboxSet's current generation blocks scaling; a missing, stale, or `Unknown` condition is treated as no signal so upgrades and first-time reconciles do not stall scale-up.
+- The controller fails open: only an explicit `True` reported against the SandboxSet's current generation blocks scaling; a missing, stale, or `Unknown` condition is treated as no signal so upgrades and first-time reconciles do not stall scale-up.
 
-Note the two same-named conditions: this `ScalingLimited` lives in the **SandboxSet** status and means the startup budget is exhausted; the PoolAutoscaler's own `ScalingLimited` (see the CRD field reference) means the desired replica count hit the `minReplicas`/`maxReplicas` bound — different semantics.
+Note the two same-named conditions: this `ScalingLimited` exists in the **SandboxSet** status and means the startup budget is exhausted; the PoolAutoscaler's own `ScalingLimited` (see the CRD field reference) means the desired replica count has hit the `minReplicas`/`maxReplicas` bound — different semantics.
 
 ### How Throttling Recovers
 
-Recovery needs no manual intervention; the budget frees automatically once either happens:
+Recovery needs no manual intervention; the budget is freed automatically once either happens:
 
-- A failed Sandbox is deleted (manually or by the business side), or its Pod returns to Running with Ready flipped to `True`;
+- A failed Sandbox is deleted (manually or by the business side), or its Pod returns to Running and its Ready condition flips to `True`;
 - A pending-timed-out Sandbox finishes starting and enters Running, or is deleted.
 
-When `Failed + TimedOut` falls back below the budget, the SandboxSet's next reconcile flips `ScalingLimited` back to `False`, and PoolAutoscaler resumes scale-up and keeps replenishing the pool.
+When `Failed + TimedOut` falls back below the budget, the SandboxSet's next reconciliation flips `ScalingLimited` back to `False`, and PoolAutoscaler resumes scale-up and keeps replenishing the pool.
 
 ### Troubleshooting
 
@@ -332,13 +330,13 @@ kubectl get events -n default --field-selector involvedObject.name=sandbox-pool
 # List Sandboxes in the pool and their status
 kubectl get sandbox -n default -l agents.kruise.io/sandbox-pool=sandbox-pool
 
-# Inspect the Ready condition of a failed instance for the concrete reason
+# Inspect the Ready condition of a failed instance for the specific reason
 kubectl get sandbox <name> -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
 ```
 
-Triage by the counters in `message`:
+Triage based on the counters in `message`:
 
-- **Mostly Failed**: usually image pull failures, resource misconfiguration, or quota exhaustion. Check the failed Sandbox's Ready condition message for the concrete reason, fix the SandboxSet configuration, then delete the failed instance:
+- **Mostly Failed**: usually image pull failures, resource misconfiguration, or quota exhaustion. Check the failed Sandbox's Ready condition message for the specific reason, fix the SandboxSet configuration, then delete the failed instance:
 
 ```bash
 kubectl delete sandbox <name> -n default
@@ -346,7 +344,7 @@ kubectl delete sandbox <name> -n default
 
 The SandboxSet recreates a new instance automatically; if the configuration is not fixed, the new instance fails again and re-triggers throttling.
 
-- **Mostly TimedOut**: the underlying creation speed cannot keep up with the scaling rhythm. Lower the SandboxSet's `scaleStrategy.maxUnavailable` to reduce the per-batch creation volume, or contact the cluster administrator to evaluate underlying supply capacity.
+- **Mostly TimedOut**: the underlying creation speed cannot keep up with the scaling rate. Lower the SandboxSet's `scaleStrategy.maxUnavailable` to reduce the per-batch creation volume, or contact the cluster administrator to evaluate underlying supply capacity.
 
 ## Capacity Policy Parameters and Scale-Down Reachability
 
@@ -383,13 +381,13 @@ Common configurations and their effects:
 | 1 | `"100%"` | any (incl. `0`) | `>= replicas` | Availability at most equals replicas, never exceeds the upper watermark; idle pool never shrinks |
 | 4 | `"70%"` | `"10%"` | 4 | Can shrink from 5 to 4 replicas |
 
-Scenario 1 demonstrates the percentage-target style: watermarks stretch with pool size, fitting fluctuating workloads. For a fixed-size pool, switch to an absolute target with `tolerance: 0`, keeping `minReplicas` no smaller than the target. Either way, verify `minReplicas` against the rules above.
+Scenario 1 demonstrates the percentage-target style: watermarks stretch with pool size, suited to fluctuating workloads. For a fixed-size pool, switch to an absolute target with `tolerance: 0`, keeping `minReplicas` no smaller than the target. Either way, verify `minReplicas` against the rules above.
 
-If the pool sits above `minReplicas` for a long time and `status.conditions` shows no anomaly, the rules above are usually unmet: lower `targetAvailable` or `tolerance`, or raise `minReplicas`, then watch whether `status.desiredReplicas` and `status.currentCapacity.available` converge.
+If the pool remains above `minReplicas` for a long time and `status.conditions` shows no anomaly, the rules above are usually not met: lower `targetAvailable` or `tolerance`, or raise `minReplicas`, then watch whether `status.desiredReplicas` and `status.currentCapacity.available` converge.
 
 ## Parameter Validation Constraints
 
-On create or update, the webhook validates the following rules; violations are rejected (HTTP 422) with the concrete reason.
+On create or update, the webhook validates the following rules; violations are rejected (HTTP 422) with the specific reason.
 
 ### General Constraints
 
@@ -407,14 +405,14 @@ On create or update, the webhook validates the following rules; violations are r
 | Field | Constraint |
 | --- | --- |
 | `targetAvailable` | An absolute value must be `>= 0` and `<= maxReplicas` (beyond that the target can never be reached); a percentage must be of the form `"<number>%"` with the number in 0 to 100. |
-| Percentage `targetAvailable` | Must come with `minReplicas >= 1`; otherwise all watermarks resolve to 0 on an empty pool and the pool cannot bootstrap itself. |
+| Percentage `targetAvailable` | Requires `minReplicas >= 1`; otherwise all watermarks resolve to 0 on an empty pool and the pool cannot bootstrap itself. |
 | `tolerance` | Same format constraints as `targetAvailable`; and must be **less than** `targetAvailable` (statically decidable when both are percentages or both are absolute), otherwise the lower watermark is clamped to 0 and scale-up never triggers. For an absolute target with a percentage tolerance, the tolerance percentage must be below 100%. |
 | `scaleUp.stabilizationWindowSeconds` | Defaults to 60 seconds when unset; explicit values must be between 60 and 3600 seconds. |
 | `scaleDown.stabilizationWindowSeconds` | Defaults to 300 seconds when unset; explicit values must be between 60 and 3600 seconds. |
 
 Scale-down reachability is not a hard validation in the current version, but a bad configuration leaves the pool unable to shrink to `minReplicas`; verify against the rules in [Ensure an Idle Pool Can Shrink to minReplicas](#ensure-an-idle-pool-can-shrink-to-minreplicas).
 
-Cron policy validation rules (at most 20 entries, unique names, valid five-field cron expressions, valid timezones, `targetReplicas >= 0`) are annotated in the CRD field reference below and are not repeated here.
+Cron policy validation rules (at most 20 entries, unique names, valid five-field cron expressions, valid timezones, `targetReplicas >= 0`) are documented in the CRD field reference below and are not repeated here.
 
 ## CRD Field Reference
 
@@ -426,7 +424,7 @@ Cron policy validation rules (at most 20 entries, unique names, valid five-field
 | `spec.capacityPolicy.tolerance` | Allowed deviation from the target, as an absolute number or percentage; defaults to `10%` when unset. For example, with target 10 and tolerance 2: scale up below 8, scale down above 12. Resolution rules and reachability constraints: see [Capacity Policy Parameters and Scale-Down Reachability](#capacity-policy-parameters-and-scale-down-reachability). |
 | `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds` | Interval between consecutive scale-ups. Explicit values must be within 60 to 3600 seconds; defaults to 60 seconds. |
 | `spec.capacityPolicy.scaleDown.stabilizationWindowSeconds` | Interval between consecutive scale-downs. Explicit values must be within 60 to 3600 seconds; defaults to 300 seconds. |
-| `spec.cronPolicies` | List of scheduled policies, at most 20, webhook-validated: `name` is required and unique within the list; `schedule` is required and must be a valid five-field cron expression (minute hour day month weekday); `timeZone` is optional and must be a valid timezone (e.g. `Asia/Shanghai`) when set; `targetReplicas` must be `>= 0` and is clamped to `maxReplicas` when exceeded. |
+| `spec.cronPolicies` | List of scheduled policies. At most 20 entries are allowed; validation is enforced by the webhook: `name` is required and unique within the list; `schedule` is required and must be a valid five-field cron expression (minute hour day month weekday); `timeZone` is optional and must be a valid timezone (e.g. `Asia/Shanghai`) when set; `targetReplicas` must be `>= 0` and is clamped to `maxReplicas` when exceeded. |
 | `spec.suspend` | Set to `true` to suspend further autoscaling; existing Sandboxes are not deleted. Resume by setting `false` or removing the field. |
 | `status.currentReplicas` | The most recently observed replica count of the target SandboxSet. |
 | `status.desiredReplicas` | The most recently computed desired replica count. |

--- a/kruiseagents/user-manuals/warmpool-management.md
+++ b/kruiseagents/user-manuals/warmpool-management.md
@@ -58,8 +58,8 @@ it through the `kubectl get` command:
 
 ```shell
 $ kubectl get sbs -n default
-NAME   REPLICAS   AVAILABLE   UPDATEREVISION   AGE
-demo   10         10          78dd8599cf       19m
+NAME   REPLICAS   AVAILABLE   UPDATEDREPLICAS   UPDATEDAVAILABLEREPLICAS   UPDATEREVISION   AGE
+demo   10         10          10                10                         78dd8599cf       19m
 ```
 
 ## Scaling the Warm Pool
@@ -84,7 +84,7 @@ Do not scale by issuing a full-object `Update` from a client — on a busy Sandb
 
 ### `scaleStrategy.maxUnavailable`
 
-This field limits the maximum number of sandboxes that can be **unavailable** (i.e., in the `creating` state) during **scaling operations**. It is useful when you want to avoid a sudden surge of Pod creation that could pressure the cluster.
+This field caps the number of sandboxes created **per batch** during scale-up, and doubles as the **startup budget** of the SandboxSet's scale-up protection. It is useful when you want to avoid a sudden surge of Pod creation that could pressure the cluster.
 
 - Can be an absolute number (e.g., `5`) or a percentage string (e.g., `"20%"`).
 - Default: no limit (all new sandboxes are created simultaneously).
@@ -93,15 +93,15 @@ This field limits the maximum number of sandboxes that can be **unavailable** (i
 spec:
   replicas: 20
   scaleStrategy:
-    # At most 5 sandboxes can be in the creating state at any time during scaling
+    # At most 5 sandboxes are created per batch during scale-up
     maxUnavailable: 5
 ```
 
 :::tip
-When scaling up, newly created sandboxes are launched in batches respecting this limit. For example, if `maxUnavailable: 5` and you scale from 0 to 20, sandboxes are created in groups of 5 — each new batch starts only after the previous batch becomes `available`.
+When scaling up, new sandboxes are created in batches of at most this limit. The next batch is issued once the controller observes the previous batch; sandboxes still in the `creating` state do not hold back further batches, so a healthy pool ramps up without waiting for each batch to become `available`.
 :::
 
-Besides pacing physical creation, this field also doubles as the **startup budget** for the SandboxSet's startup protection: sandboxes that fail definitively to start (Ready condition `False` with reason `StartContainerFailed`, `PodCreateFailed`, or `Unschedulable`) or that stay stuck in Creating/ResourcePending past the pending timeout (default 50 seconds) occupy the budget. When such sandboxes exhaust the budget, the SandboxSet reports `ScalingLimited=True` with reason `StartupBudgetExhausted` in `status.conditions`, and controllers such as [PoolAutoscaler](./poolautoscaler.md) pause further scale-up until the budget recovers. Scale-down is never affected by this field.
+A sandbox only occupies the startup budget when it is definitively failing to start: its Ready condition is `False` with reason `StartContainerFailed`, `PodCreateFailed`, or `Unschedulable`, or it stays stuck in Creating/ResourcePending past the pending timeout (default 50 seconds). Healthy `creating` sandboxes do not consume the budget. When failing sandboxes exhaust the budget, the SandboxSet reports `ScalingLimited=True` with reason `StartupBudgetExhausted` in `status.conditions`, and controllers such as [PoolAutoscaler](./poolautoscaler.md) pause further scale-up until the budget recovers. Scale-down is never affected by this field.
 
 For the trigger conditions, recovery behavior, and troubleshooting of this startup protection, see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](./poolautoscaler.md#failure-scenario-scale-up-throttling-trigger-and-recovery) in the PoolAutoscaler manual.
 
@@ -205,7 +205,7 @@ my-sandbox-pool   10         8           6                 5                    
 
 | Field | Description |
 |---|---|
-| `REPLICAS` | Total number of sandboxes (creating + available + running + paused) |
+| `REPLICAS` | Total number of pool sandboxes (creating + available); sandboxes claimed by agents are not counted |
 | `AVAILABLE` | Number of sandboxes ready to be claimed |
 | `UPDATEDREPLICAS` | Number of sandboxes that have been updated to the latest revision |
 | `UPDATEDAVAILABLEREPLICAS` | Number of updated sandboxes that are available |

--- a/kruiseagents/user-manuals/warmpool-management.md
+++ b/kruiseagents/user-manuals/warmpool-management.md
@@ -101,6 +101,10 @@ spec:
 When scaling up, newly created sandboxes are launched in batches respecting this limit. For example, if `maxUnavailable: 5` and you scale from 0 to 20, sandboxes are created in groups of 5 — each new batch starts only after the previous batch becomes `available`.
 :::
 
+Besides pacing physical creation, this field also doubles as the **startup budget** for the SandboxSet's startup protection: sandboxes that fail definitively to start (Ready condition `False` with reason `StartContainerFailed`, `PodCreateFailed`, or `Unschedulable`) or that stay stuck in Creating/ResourcePending past the pending timeout (default 50 seconds) occupy the budget. When such sandboxes exhaust the budget, the SandboxSet reports `ScalingLimited=True` with reason `StartupBudgetExhausted` in `status.conditions`, and controllers such as [PoolAutoscaler](./poolautoscaler.md) pause further scale-up until the budget recovers. Scale-down is never affected by this field.
+
+For the trigger conditions, recovery behavior, and troubleshooting of this startup protection, see [Failure Scenario: Scale-Up Throttling, Trigger and Recovery](./poolautoscaler.md#failure-scenario-scale-up-throttling-trigger-and-recovery) in the PoolAutoscaler manual.
+
 ## Upgrading Pre-warmed Pool Sandboxes
 
 When you modify the `spec.template` field of a SandboxSet, the controller detects the template change and performs a **rolling update** of the sandboxes in the pool.

--- a/sidebars-kruiseagents.js
+++ b/sidebars-kruiseagents.js
@@ -28,6 +28,7 @@ module.exports = {
             collapsed: false,
             items: [
                 'user-manuals/warmpool-management',
+                'user-manuals/poolautoscaler',
                 'user-manuals/sandbox-claim',
                 'user-manuals/sandbox-id',
                 'user-manuals/pause-resume',


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds a bilingual (EN/ZH) user manual for PoolAutoscaler, the warm-pool autoscaling capability of Kruise Agents, covering:

- **Background and use cases**: when to use PoolAutoscaler vs. metric-based autoscaling
- **Step-by-step guide**:
  1. Create the warm-pool SandboxSet (with runtime injection required for E2B verification)
  2. Configure the PoolAutoscaler capacity policy (percentage-based demo)
  3. Run business traffic to verify scaling, using an embedded single-file Python script based on the E2B SDK (no local test project needed)
  4. Observe scaling behavior and startup protection (ScalingLimited)
  5. Optionally remove the policy when no longer needed
- **Capacity policy watermarks and scale-down reachability**: how targets and tolerance form the dead zone, the `minReplicas+1` upper-watermark rule, and why `targetAvailable: "100%"` makes an idle pool never shrink
- **Parameter configuration constraints**: webhook validation rules for general fields, capacity policy, and cron policies
- **Exception scenarios**: scale-up rate limiting — budget source (`scaleStrategy.maxUnavailable`), Failed/TimedOut counters, ScalingLimited condition, automatic recovery, and troubleshooting commands
- **CRD field reference**

The page is registered in `sidebars-kruiseagents.js` under User Manuals, right after Warm Pool Management, which it builds upon.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Both language versions are added in the same change and stay structurally aligned (headings, code blocks, embedded script are byte-identical).
2. Embedded verification script: extracted with `sed`, passes `python3 -m py_compile`; `--help` and the missing-`E2B_API_KEY` error path verified.
3. Sidebar entry registered; `node -e "require('./sidebars-kruiseagents.js')"` passes.
4. Constraint tables cross-checked against `pkg/webhook/poolautoscaler/validating` in openkruise/agents.

### Ⅳ. Special notes for reviews

- Follows the bilingual doc contract from the repo AGENTS.md: EN source + ZH mirror added together, same structure.
- The verification script intentionally keeps only the core business loop (create → run_code → file write/read → command → hold → kill); pool observation is left to the kubectl commands in step 4.
- Requires PoolAutoscaler GA in the agents repo (feature gate default-on landed as openkruise/agents#938).
