### PR TITLE
docs: fix broken links, wrong locales, and leftover translation

### DIFF
--- a/docs/best-practices/ci-pipeline-image-predownload.md
+++ b/docs/best-practices/ci-pipeline-image-predownload.md
@@ -28,7 +28,7 @@ DevOps is an extension of CI/CD, and CI/CD is the core foundation of DevOps. Wit
 - Install Kubernetes Cluster, Since v1.0.0 (alpha/beta), OpenKruise requires Kubernetes version >= 1.16.
 - Install Tekton, Reference [Official Documents](https://tekton.dev/docs/getting-started/)。
 Tekton is a Google open source Kubernetes native framework for creating continuous integration and continuous deployment/delivery (CI/CD) systems.
-- Helm installation of OpenKruise, Since v0.9.0, Reference [Install OpenKruise](https://openkruise.io/zh/docs/installation)。
+- Helm installation of OpenKruise, Since v0.9.0, Reference [Install OpenKruise](https://openkruise.io/docs/installation).
 
 ### Build-Test-Docker Push
 **1. Git Repo: This article provides a helloworld http service [demo](https://github.com/zmberg/samples/tree/hello_world/helloworld), It contains Code, Dockerfile, and Unit Test, as follows:**

--- a/docs/best-practices/cloneset-lifecycle.md
+++ b/docs/best-practices/cloneset-lifecycle.md
@@ -39,7 +39,7 @@ CloneSet Lifecycle defines the pod life cycle via the following 5 states:
 - Updated: the pod upgrade is completed.
 - PreparingDelete: the CloneSet is preparing to delete the pod. The pod deletion will be blocked, so as to wait for users to execute hook and do some preprocessing operations before deletion;
 
-The transition logic among the above five states is controlled by a state machine, which is explained in detail in [CloneSet official document] (https://openkruise.io/docs/user-manuals/cloneset/#lifecycle-hook). Users can select one or more of their concerns, implement an independent operator to manage the pod life cycle states, control the life cycle of pod, and insert customized logic at the time spots they are concerned about.
+The transition logic among the above five states is controlled by a state machine, which is explained in detail in [CloneSet official document](https://openkruise.io/docs/user-manuals/cloneset/#lifecycle-hook). Users can select one or more of their concerns, implement an independent operator to manage the pod life cycle states, control the life cycle of pod, and insert customized logic at the time spots they are concerned about.
 
 ### CloneSet Lifecycle Configuration
 ```yaml

--- a/docs/best-practices/log-container-sidecarset.md
+++ b/docs/best-practices/log-container-sidecarset.md
@@ -207,9 +207,9 @@ Below are two windows, and on the right is a client request to access the nginx 
 
 ![k8s log sidecar](/img/docs/best-practices/update-sidecarset.gif)
 
-This feature relies on the ability of [Kruise InPlace Update](https://openkruise.io/docs/next/core-concepts/inplace-update/).
+This feature relies on the ability of [Kruise InPlace Update](https://openkruise.io/docs/core-concepts/inplace-update/).
 However, upgrading sidecar independently comes with a risk, if the sidecar upgrade process fails, it will make Pod Not Ready and potentially affects the business, so SidecarSet itself provides rich progressive delivery capability to mitigate the risk.
-Refer to [Kruise SidecarSet](https://openkruise.io/zh/docs/next/user-manuals/sidecarset#sidecar%E6%9B%B4%E6%96%B0%E7%AD%96%E7%95%A5), as follows:
+Refer to [Kruise SidecarSet](https://openkruise.io/docs/user-manuals/sidecarset#sidecarset-update-strategy), as follows:
 ```yaml
 apiVersion: apps.kruise.io/v1alpha1
 kind: SidecarSet
@@ -230,7 +230,7 @@ spec:
         # or any other labels where a small number of pods can be selected
         deploy-env: canary
 ```
-**In addition, if it is similar to the ServiceMesh Envoy Mesh Container, you need to use the SidecarSet hot upgrade feature,** Refer to [SidecarSet HotUpgrade](https://openkruise.io/docs/next/user-manuals/sidecarset#sidecar%E7%83%AD%E5%8D%87%E7%BA%A7%E7%89%B9%E6%80%A7).
+**In addition, if it is similar to the ServiceMesh Envoy Mesh Container, you need to use the SidecarSet hot upgrade feature,** Refer to [SidecarSet HotUpgrade](https://openkruise.io/docs/user-manuals/sidecarset#hot-upgrade-sidecar).
 
 ### Argo-cd Deploy SidecarSet (Optional)
 If you use Argo-cd to deploy Kruise SidecarSet, you need to configure [Custom CRD Health Checks](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#custom-health-checks).

--- a/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/runtime-injection.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruiseagents/current/user-manuals/runtime-injection.md
@@ -11,7 +11,7 @@ SandboxSet、SandboxClaim、SandboxTemplate 或 Sandbox）中配置 `runtimes` �
 | 注入类型              | `runtimes.name` | 说明                                                                    |
 |-------------------|-----------------|-----------------------------------------------------------------------|
 | **Agent Runtime** | `agent-runtime` | 注入 `agent-runtime`（兼容 envd）组件，提供 E2B 命令执行（`commands.run`）、文件系统读写等高级功能 |
-| **CSI 挂载**        | `csi`           | 注入 CSI 挂载 sidecar，支持[动态持久化卷挂载](./sandbox-claim.md#动态挂载持久化卷)           |
+| **CSI 挂载**        | `csi`           | 注入 CSI 挂载 sidecar，支持[按需挂载持久化卷](./sandbox-claim.md#按需挂载持久化卷)           |
 
 ## 工作机制
 
@@ -133,7 +133,7 @@ spec:
 
 在以下场景下，你应当配置 `csi` 注入：
 
-- 需要使用[动态持久化卷挂载](./sandbox-claim.md#动态挂载持久化卷)功能，在获取沙箱时将 PV 挂载到沙箱中
+- 需要使用[按需挂载持久化卷](./sandbox-claim.md#按需挂载持久化卷)功能，在获取沙箱时将 PV 挂载到沙箱中
 
 > `csi` 注入通常与 `agent-runtime` 注入一起使用。
 

--- a/i18n/zh/docusaurus-plugin-content-docs-kruisegame/current/best-practices/session-based-game.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-kruisegame/current/best-practices/session-based-game.md
@@ -205,7 +205,7 @@ spec:
 
 ### 房间服自动减少
 
-在状态管理一节中，我们也有所提到，opsState为WaitToBeDeleted的GameServer将会自动被OKG回收。这样一来，只要业务决定了自身不再提供服务了，通过自定义服务质量设置WaitToBeDeleted即可。关于缩容策略的具体的配置可以参考 [https://openkruise.io/zh/kruisegame/user-manuals/gameservers-scale#使用示例](https://openkruise.io/zh/kruisegame/user-manuals/gameservers-scale#%E4%BD%BF%E7%94%A8%E7%A4%BA%E4%BE%8B)
+在状态管理一节中，我们也有所提到，opsState为WaitToBeDeleted的GameServer将会自动被OKG回收。这样一来，只要业务决定了自身不再提供服务了，通过自定义服务质量设置WaitToBeDeleted即可。关于缩容策略的具体的配置可以参考 [游戏服伸缩](https://openkruise.io/zh/kruisegame/user-manuals/gameservers-scale#缩容策略)
 
 ### 房间服自动增加
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/log-container-sidecarset.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/best-practices/log-container-sidecarset.md
@@ -206,9 +206,9 @@ status:
 
 ![k8s log sidecar](/img/docs/best-practices/update-sidecarset.gif)
 
-该特性依赖Kruise原地升级的能力实现，详情参考文档：[Kruise原地升级](https://openkruise.io/zh/docs/next/core-concepts/inplace-update/)。
+该特性依赖Kruise原地升级的能力实现，详情参考文档：[Kruise原地升级](https://openkruise.io/zh/docs/core-concepts/inplace-update/)。
 不过独立升级sidecar容器也存在一定的风险性，如果sidecar容器升级过程中失败，则将导致Pod Not Ready，进而影响业务，因此SidecarSet本身提供了非常丰富的灰度发布能力来尽量规避该风险，
-详情参考文档：[Kruise SidecarSet](https://openkruise.io/zh/docs/next/user-manuals/sidecarset#sidecar%E6%9B%B4%E6%96%B0%E7%AD%96%E7%95%A5)，如下：
+详情参考文档：[Kruise SidecarSet](https://openkruise.io/zh/docs/user-manuals/sidecarset#sidecar更新策略)，如下：
 ```yaml
 apiVersion: apps.kruise.io/v1alpha1
 kind: SidecarSet
@@ -229,7 +229,7 @@ spec:
         # or any other labels where a small number of pods can be selected
         deploy-env: canary
 ```
-**另外，如果是类似于ServiceMesh Envoy Mesh类容器则需要借助于SidecarSet热升级特性**，详情请参考：[SidecarSet热升级](https://openkruise.io/zh/docs/next/user-manuals/sidecarset#sidecar%E7%83%AD%E5%8D%87%E7%BA%A7%E7%89%B9%E6%80%A7)。
+**另外，如果是类似于ServiceMesh Envoy Mesh类容器则需要借助于SidecarSet热升级特性**，详情请参考：[SidecarSet热升级](https://openkruise.io/zh/docs/user-manuals/sidecarset#sidecar热升级特性)。
 
 ### Argo-cd部署SidecarSet（Optional）
 如果使用Argo-cd发布Kruise SidecarSet，则需要配置 [SidecarSet Custom CRD Health Checks](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#custom-health-checks)。

--- a/kruiseagents/user-manuals/runtime-injection.md
+++ b/kruiseagents/user-manuals/runtime-injection.md
@@ -17,7 +17,7 @@ Runtime Injection currently supports the following two injection types:
 | Injection Type    | `runtimes.name` | Description                                                                                                                                                    |
 |-------------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Agent Runtime** | `agent-runtime` | Injects the `agent-runtime` (envd compatible) component, providing E2B command execution (`commands.run`), file system read/write, and other advanced features |
-| **CSI Mount**     | `csi`           | Injects the CSI mount sidecar, enabling [dynamic persistent volume mounting](./sandbox-claim.md#dynamic-persistent-volume-mounting)                            |
+| **CSI Mount**     | `csi`           | Injects the CSI mount sidecar, enabling [on-demand persistent volume mounting](./sandbox-claim.md#on-demand-persistent-volume-mounting)                            |
 
 ## How It Works
 
@@ -146,7 +146,7 @@ For more details, see the [E2B SDK Integration Documentation](./e2b-client.md).
 
 You should configure `csi` injection when:
 
-- You need to use [dynamic persistent volume mounting](./sandbox-claim.md#dynamic-persistent-volume-mounting) to mount
+- You need to use [on-demand persistent volume mounting](./sandbox-claim.md#on-demand-persistent-volume-mounting) to mount
   PVs into sandboxes at claim time
 
 > `csi` injection is typically used together with `agent-runtime` injection.

--- a/kruiseagents/user-manuals/sandbox-claim.md
+++ b/kruiseagents/user-manuals/sandbox-claim.md
@@ -337,13 +337,13 @@ spec:
   </TabItem>
 </Tabs>
 
-### Ondemand Persistent Volume Mounting
+### On-demand Persistent Volume Mounting
 
 You can dynamically mount a PV when claiming a sandbox, specifying a separate mount volume for each sandbox. This
 capability relies on `agent-runtime` injected into the Sandbox
 and will also affect delivery efficiency to some extent.
 
-> ⚠️ To use ondemand persistent volume mounting, you must configure `csi` in the `runtimes` field of your SandboxSet. For
+> ⚠️ To use on-demand persistent volume mounting, you must configure `csi` in the `runtimes` field of your SandboxSet. For
 > details, refer to the [Runtime Injection](./runtime-injection.md) documentation.
 
 <Tabs>

--- a/kruisegame/best-practices/session-based-game.md
+++ b/kruisegame/best-practices/session-based-game.md
@@ -89,14 +89,14 @@ WaitToBeDeleted (About to be deleted, waiting for OKG to recycle the pod)
 These three states can be recorded in the GameServer Spec using OpsState. OKG provides two ways to mark the server state:
 
 1. Modifying GameServer.Spec.OpsState directly by calling the Kubernetes API (usually after the matchmaking system assigns the game server, it can be marked as Allocated).
-2. Exposing and converting the business state in a container to the corresponding GameServer.Spec.OpsState by [Service Quality](https://openkruise.io/zh/kruisegame/user-manuals/service-qualities).
+2. Exposing and converting the business state in a container to the corresponding GameServer.Spec.OpsState by [Service Quality](https://openkruise.io/kruisegame/user-manuals/service-qualities).
 
 
 The simplest state transition model is shown in the figure:
 
 1. The default state after the room server is pulled up is available. At this time, OpsState is **None**
 2. When matching requirements are generated, the matching service searches for available (Infrastructure Ready & OpsState is None) room servers, and after allocation, sets its OpsState to **Allocated** (set through Kubernetes API, please refer to [kruise-game -allocator code for open-match-director](https://github.com/CloudNativeGame/kruise-game-open-match-director/blob/main/pkg/allocator.go). Not required if using OKG + Open Match Settings, Director has already done the above work)
-3. Setting OpsState as **WaitToBeDeleted** when game over by [Service Quality](https://openkruise.io/zh/kruisegame/user-manuals/service-qualities). 这样对应的pod将被OKG自动进行回收删除，后续弹性伸缩部分将展开介绍。
+3. Setting OpsState as **WaitToBeDeleted** when game over by [Service Quality](https://openkruise.io/kruisegame/user-manuals/service-qualities). OKG then recycles and deletes the corresponding Pod; the elastic scaling section below covers this in more detail.
 
 <img src={require('/static/img/kruisegame/best-practices/session-based-game-state-1.png').default} style={{  width: '150px'}} />
 
@@ -104,8 +104,8 @@ Of course, if you want to start and stop pods less frequently, you can also chan
 
 1. Same as above, the default state after the room server is pulled up is available, at this time OpsState is **None**
 2. Same as above, after assigning the room server, the matching system will set it to **Allocated**
-3. When the game ends, set OpsState to **None** through [Customized Service Quality](https://openkruise.io/zh/kruisegame/user-manuals/service-qualities)
-4. When the room server status is judged to be None for a long time through the coroutine, the OpsState will be set to ** through [Customized Service Quality](https://openkruise.io/zh/kruisegame/user-manuals/service-qualities) WaitToBeDeleted. **
+3. When the game ends, set OpsState to **None** through [Customized Service Quality](https://openkruise.io/kruisegame/user-manuals/service-qualities)
+4. When the room server status is judged to be None for a long time through the coroutine, the OpsState will be set to **WaitToBeDeleted** through [Customized Service Quality](https://openkruise.io/kruisegame/user-manuals/service-qualities).
 
 <img src={require('/static/img/kruisegame/best-practices/session-based-game-state-2.png').default} style={{  width: '200px'}} />
 
@@ -198,7 +198,7 @@ The ideal state for elastic scaling of conversational games is that during peak 
 
 ### Room service is automatically reduced
 
-In the state management section, we also mentioned that the GameServer whose opsState is WaitToBeDeleted will be automatically recycled by OKG. In this way, as long as the business decides that it will no longer provide services, it can set WaitToBeDeleted through custom service quality. For specific configuration of the scaling strategy, please refer to [https://openkruise.io/zh/kruisegame/user-manuals/gameservers-scale#Usage Example](https://openkruise.io/zh/kruisegame/user-manuals /gameservers-scale#%E4%BD%BF%E7%94%A8%E7%A4%BA%E4%BE%8B)
+In the state management section, we also mentioned that the GameServer whose opsState is WaitToBeDeleted will be automatically recycled by OKG. In this way, as long as the business decides that it will no longer provide services, it can set WaitToBeDeleted through custom service quality. For specific configuration of the scaling strategy, please refer to [Gameservers Scale](https://openkruise.io/kruisegame/user-manuals/gameservers-scale#strategy-of-scale-down).
 
 ### Room service automatically added
 

--- a/rollouts/developer-manuals/custom-network-provider.md
+++ b/rollouts/developer-manuals/custom-network-provider.md
@@ -247,7 +247,7 @@ When designing test cases, at least the release strategies listed below are supp
       value: ".*demo"
 ```
 
-**Please visit** [API Specifications | OpenKruise](https://openkruise.io/zh/rollouts/user-manuals/api-specifications) **for more information about the difference of the above mentioned two release strategies.**
+**Please visit** [API Specifications | OpenKruise](https://openkruise.io/rollouts/user-manuals/api-specifications) **for more information about the difference of the above mentioned two release strategies.**
 
 - Release strategy without header matches, and the traffic is routed to canary service with a certain weight.
 


### PR DESCRIPTION
## Summary
- Point English current docs at English routes and drop stale `/docs/next` paths.
- Repair the CloneSet lifecycle Markdown link, session-based game leftover Chinese / broken scale URL, and CSI heading anchors.
- Keep the matching Chinese pages aligned.

Fixes #404

